### PR TITLE
[Fix/YB-180] JwtAuthFilter 가 항상 실행되는 문제 해결

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/config/SecurityConfig.java
+++ b/yellobook-api/src/main/java/com/yellobook/config/SecurityConfig.java
@@ -3,12 +3,15 @@ package com.yellobook.config;
 import com.yellobook.domain.auth.security.filter.JwtAuthFilter;
 import com.yellobook.domain.auth.security.oauth2.handler.CustomSuccessHandler;
 import com.yellobook.domain.auth.security.oauth2.service.CustomOAuth2UserService;
+import com.yellobook.domain.auth.service.JwtService;
+import com.yellobook.domain.auth.service.RedisAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -22,21 +25,27 @@ import java.util.Arrays;
 import java.util.Collections;
 
 @Configuration
-@EnableMethodSecurity // 찾아보기
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
-    private final JwtAuthFilter jwtAuthFilter;
 
     @Value("${frontend.base-url}")
     private String frontendBaseURL;
 
-    // 정적 파일은 필터들 타지 않도록
+    /**
+     * 정적 파일은 필터들은 명시적으로 필터를 타지 않도록 한다.
+     * debug 로 확인해 보았을 때
+     * 설정하지 않으면 Security filter chain: no match
+     * 설정하면 Security filter chain: [] empty (bypassed by security='none')
+     */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(
+                new AntPathRequestMatcher("/public/**"),
+                new AntPathRequestMatcher("/favicon.ico"),
                 new AntPathRequestMatcher("/swagger-ui/**"),
                 new AntPathRequestMatcher("/v3/api-docs/**")
         );
@@ -81,7 +90,7 @@ public class SecurityConfig {
 
     // jwt 인가용 필터체인
     @Bean
-    public SecurityFilterChain jwtSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain jwtSecurityFilterChain(HttpSecurity http, JwtService jwtService, RedisAuthService redisAuthService) throws Exception {
         http
                 .securityMatchers(auth -> auth
                         .requestMatchers(
@@ -92,7 +101,13 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                /**
+                 * JwtAuthFilter 를 @Component 로 등록하면 WebSecurityCustomizer 에서 ignoring 을 해준 경로에도 jwt 필터가 실행된다.
+                 * 관련 링크: https://stackoverflow.com/questions/39152803/spring-websecurity-ignoring-doesnt-ignore-custom-filter/40969780#40969780
+                 * shouldNotFilter 로 jwt 필터에서 해당 경로를 타지 않도록 해주거나
+                 * 아래처럼 컴포넌트로 등록하지 않고, 수동으로 등록하는 방법을 사용할 수 있다.
+                 */
+                .addFilterBefore(new JwtAuthFilter(jwtService, redisAuthService), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests((auth) -> auth
                         // 헬스 체크 경로는 jwt 인증 비활성화
                         .requestMatchers("/api/v1/","/api/v1/health","/api/v1/auth/terms").permitAll()
@@ -103,4 +118,3 @@ public class SecurityConfig {
         return http.build();
     }
 }
-

--- a/yellobook-api/src/main/java/com/yellobook/domain/auth/service/AuthService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domain/auth/service/AuthService.java
@@ -59,6 +59,12 @@ public class AuthService {
     }
 
     public void logout(String accessToken, Long memberId) {
+        Long tokenMemberId = jwtService.getMemberIdFromAccessToken(accessToken);
+        //  본인 확인
+        if (!tokenMemberId.equals(memberId)) {
+            log.warn("사용자 :{} 가 본인이 아닌 사용자에 대한 로그아웃 요청", tokenMemberId);
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED_ACCESS);
+        }
         long expirationTime = jwtService.getAllowanceTokenExpirationTimeInMillis(accessToken);
 
         // 토큰을 블랙리스트에 추가

--- a/yellobook-api/src/main/java/com/yellobook/domain/auth/service/JwtService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domain/auth/service/JwtService.java
@@ -58,70 +58,149 @@ public class JwtService {
         allowanceTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(allowanceSecret));
     }
 
-    public String resolveToken(HttpServletRequest request) {
+    /**
+     * 요청 헤더에서 JWT 액세스 토큰을 추출한다.
+     * @param request HTTP 요청 객체
+     * @return JWT 액세스 토큰 문자열
+     */
+    public String resolveAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
             return bearerToken.substring(BEARER_PREFIX.length());
         }
-        // 에러 처리 추가 요망
-        return null;
+        log.info("[AUTH_INFO] 요청 헤더에 JWT 토큰이 존재하지 않음");
+        throw new CustomException(AuthErrorCode.ACCESS_TOKEN_NOT_FOUND);
     }
 
+    /**
+     * 사용자 ID로 JWT 액세스 토큰을 생성한다.
+     * @param memberId 사용자 ID
+     * @return 생성된 JWT 액세스 토큰 문자열
+     */
     public String createAccessToken(Long memberId) {
         return createToken(memberId, accessTokenExpiresIn, accessTokenSecretKey);
     }
 
+    /**
+     * 사용자 ID로 JWT 리프레시 토큰을 생성한다.
+     * @param memberId 사용자 ID
+     * @return 생성된 JWT 리프레시 토큰 문자열
+     */
     public String createRefreshToken(Long memberId) {
         String refreshToken = createToken(memberId, refreshTokenExpiresIn, refreshTokenSecretKey);
         redisService.setRefreshToken(memberId, refreshToken, refreshTokenExpiresIn);
         return refreshToken;
     }
 
+    /**
+     * 사용자 ID로 JWT 약관 동의 토큰을 생성한다.
+     * @param memberId 사용자 ID
+     * @return 생성된 JWT 약관 동의 토큰 문자열
+     */
     public String createAllowanceToken(Long memberId) {
         return createToken(memberId, allowanceTokenExpiresIn, allowanceTokenSecretKey);
     }
 
-    public boolean isAllowanceTokenExpired(String allowanceToken) throws CustomException {
+    /**
+     * 약관 동의 토큰이 만료되었는지 확인한다.
+     * @param allowanceToken 약관 동의 토큰
+     * @return 토큰이 만료되었는지 여부
+     */
+    public boolean isAllowanceTokenExpired(String allowanceToken) {
         return isTokenExpired(allowanceToken, allowanceTokenSecretKey);
     }
 
-    public boolean isAccessTokenExpired(String accessToken) throws CustomException {
+    /**
+     * 액세스 토큰이 만료되었는지 확인한다.
+     * @param accessToken 액세스 토큰
+     * @return 토큰이 만료되었는지 여부
+     */
+    public boolean isAccessTokenExpired(String accessToken) {
         return isTokenExpired(accessToken, accessTokenSecretKey);
     }
 
-    public boolean isRefreshTokenExpired(String refreshToken) throws CustomException {
+    /**
+     * 리프레시 토큰이 만료되었는지 확인한다.
+     * @param refreshToken 리프레시 토큰
+     * @return 토큰이 만료되었는지 여부
+     */
+    public boolean isRefreshTokenExpired(String refreshToken) {
         return isTokenExpired(refreshToken, refreshTokenSecretKey);
     }
 
-
+    /**
+     * 유효한 액세스 토큰에서 사용자 정보를 추출한다.
+     * 토큰 만료 여부 검사 필요.
+     * @param token JWT 액세스 토큰
+     * @return 액세스 토큰에서 추출된 사용자 정보
+     */
     public Member getMemberFromAccessToken(String token) {
         Long memberId = getMemberIdFromAccessToken(token);
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+                .orElseThrow(() -> {
+                    log.error("[AUTH_ERROR] 유효한 엑세스 토큰에서 추출된 사용자 ID: {}에 해당하는 사용자가 존재하지 않음", memberId);
+                    return new CustomException(AuthErrorCode.AUTHENTICATION_FAILED);
+                });
     }
+
+    /**
+     * 유효한 약관 동의 토큰에서 사용자 정보를 추출한다.
+     * 토큰 만료 여부 검사 필요.
+     * @param token JWT 약관 동의 토큰
+     * @return 약관 동의 토큰에서 추출된 사용자 정보
+     */
     public Member getMemberFromAllowanceToken(String token) {
         Long memberId = getMemberIdFromAllowanceToken(token);
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_EXIST));
+                .orElseThrow(() -> {
+                    log.error("[AUTH_ERROR] 유효한 약관 동의 토큰에서 추출된 사용자 ID: {}에 해당하는 사용자가 존재하지 않음", memberId);
+                    return new CustomException(AuthErrorCode.USER_NOT_EXIST);
+                });
     }
 
+    /**
+     * 약관 동의 토큰의 만료 시간을 밀리초 단위로 반환한다.
+     * @param token JWT 약관 동의 토큰
+     * @return 토큰의 남은 유효 기간 (밀리초 단위)
+     */
     public long getAllowanceTokenExpirationTimeInMillis(String token) {
         return extractAll(token, allowanceTokenSecretKey)
                 .getExpiration().getTime() - System.currentTimeMillis();
     }
 
+    /**
+     * 약관 동의 토큰에서 사용자 ID를 추출한다.
+     * @param token JWT 약관 동의 토큰
+     * @return 약관 동의 토큰에서 추출된 사용자 ID
+     */
     public Long getMemberIdFromAllowanceToken(String token) {
         return parseMemberId(token, allowanceTokenSecretKey);
     }
 
+    /**
+     * 액세스 토큰에서 사용자 ID를 추출한다.
+     * @param token JWT 액세스 토큰
+     * @return 액세스 토큰에서 추출된 사용자 ID
+     */
     public Long getMemberIdFromAccessToken(String token) {
         return parseMemberId(token, accessTokenSecretKey);
     }
 
+    /**
+     * 리프레시 토큰에서 사용자 ID를 추출한다.
+     * @param token JWT 리프레시 토큰
+     * @return 리프레시 토큰에서 추출된 사용자 ID
+     */
     public Long getMemberIdFromRefreshToken(String token) {
         return parseMemberId(token, refreshTokenSecretKey);
     }
 
+    /**
+     * JWT 토큰의 모든 클레임을 추출한다.
+     * @param token JWT 토큰
+     * @param secretKey JWT 비밀키
+     * @return JWT 토큰에서 추출된 클레임
+     */
     private Claims extractAll(String token, SecretKey secretKey) {
         return Jwts.parser().verifyWith(secretKey)
                 .build()
@@ -129,6 +208,13 @@ public class JwtService {
                 .getPayload();
     }
 
+    /**
+     * 사용자 ID를 포함하는 JWT 토큰을 생성한다.
+     * @param memberId 사용자 ID
+     * @param expiresIn 토큰 유효 기간 (초 단위)
+     * @param secretKey JWT 비밀키
+     * @return 생성된 JWT 토큰
+     */
     private String createToken(Long memberId, long expiresIn, SecretKey secretKey) {
         return Jwts.builder()
                 .claim("memberId", memberId)
@@ -138,27 +224,40 @@ public class JwtService {
                 .compact();
     }
 
+    /**
+     * JWT 토큰에서 사용자 ID를 추출한다.
+     * @param token JWT 토큰
+     * @param secretKey JWT 비밀키
+     * @return JWT 토큰에서 추출된 사용자 ID
+     */
     private Long parseMemberId(String token, SecretKey secretKey) {
-        return extractAll(token,secretKey)
-                .get("memberId",Long.class);
+        return extractAll(token, secretKey)
+                .get("memberId", Long.class);
     }
 
+    /**
+     * JWT 토큰이 만료되었는지 확인한다.
+     * @param token JWT 토큰
+     * @param secretKey JWT 비밀키
+     * @return 토큰이 만료되었는지 여부
+     */
     private boolean isTokenExpired(String token, SecretKey secretKey) {
         try {
-            return extractAll(token,secretKey)
+            return extractAll(token, secretKey)
                     .getExpiration()
                     .before(new Date());
         } catch (JwtException e) {
             if (e instanceof MalformedJwtException) {
-                log.warn("올바르지 않은 형식의 JWT 토큰: {}", e.getMessage());
+                log.warn("[AUTH_WARNING] JWT 토큰 형식이 올바르지 않음: {}", e.getMessage());
             } else if (e instanceof SignatureException) {
-                log.warn("JWT 서명이 일치하지 않음: {}", e.getMessage());
+                log.warn("[AUTH_WARNING] JWT 토큰의 서명이 일치하지 않음: {}", e.getMessage());
             } else if (e instanceof UnsupportedJwtException) {
-                log.warn("토큰의 특정 헤더나 클레임이 지원되지 않음: {}", e.getMessage());
+                log.warn("[AUTH_WARNING] JWT 토큰의 특정 헤더나 클레임이 지원되지 않음: {}", e.getMessage());
             } else {
-                log.warn("JWT 만료기간 검사 처리 중 오류 발생: {}", e.getMessage());
+                log.info("[AUTH_INFO] JWT 토큰이 만료: {}", e.getMessage());
             }
             throw new CustomException(AuthErrorCode.AUTHENTICATION_FAILED);
         }
     }
+
 }

--- a/yellobook-common/src/main/java/com/yellobook/error/code/AuthErrorCode.java
+++ b/yellobook-common/src/main/java/com/yellobook/error/code/AuthErrorCode.java
@@ -16,13 +16,14 @@ public enum AuthErrorCode implements ErrorCode {
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-004", "로그인에 실패했습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-005", "토큰의 유효기간이 만료되었습니다."),
     INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-006", "잘못된 토큰 형식입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-007", "쿠키에 refreshToken이 없습니다."),
-
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-007", "쿠키에 refreshToken 이 없습니다."),
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-007", "헤더에 accessToken 이 없습니다."),
     // 권한 애러
     ADMIN_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "AUTH-008", "관리자는 접근 권한이 없습니다."),
     ORDERER_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "AUTH-009", "주문자는 접근 권한이 없습니다."),
     VIEWER_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "AUTH-010", "뷰어는 접근 권한이 없습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH-011", "권한이 없는 접근입니다."),
+
     // 약관 동의여부
     USER_NOT_EXIST(HttpStatus.UNAUTHORIZED, "AUTH_012", "가입한 사용자가 존재하지 않습니다.");
 


### PR DESCRIPTION
### 문제상황

- jwt 필터를 컴포넌트로 등록했더니 `WebSecurityCustomizer` 에서 swagger 를 ignoring 해주었음에도 불구하고 swagger 문서를 로드할때 jwt 필터가 실행

- `Security filter chain: [] empty (bypassed by security='none')` 가 적용된 것이 디버그로그에 찍혔으므로 보안 필터 체인(Security Filter Chain)을 완전히 우회함에도 불구하고 jwt 필터가 실행되는 버그 발생

![image](https://github.com/user-attachments/assets/b5f92952-18eb-46fe-bcfd-313506f2bec1)



### 작업내용

스택오버플로우 아래 답변을 참고해 필터를 컴포넌트로 등록하지 않고 수동 등록으로 해결했다.

https://stackoverflow.com/questions/39152803/spring-websecurity-ignoring-doesnt-ignore-custom-filter/40969780#40969780

 
