### PR TITLE
[Feature/YB-373] 팀내 모든 멤버 조회기능 추가

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
@@ -18,9 +18,11 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/teams")
@@ -29,7 +31,7 @@ public class TeamController {
     private final TeamCommandService teamCommandService;
     private final TeamQueryService teamQueryService;
 
-    @PostMapping("")
+    @PostMapping
     @Operation(summary = "팀 만들기 API", description ="새로운 팀을 생성하는 API입니다.")
     public ResponseEntity<SuccessResponse<CreateTeamResponse>> createTeam(
             @RequestBody CreateTeamRequest request,
@@ -40,7 +42,7 @@ public class TeamController {
     }
 
     @PostMapping("/{teamId}/invite")
-    @Operation(summary = "팀 초대하기 API", description = "팀원이 다른 구성원을 초대하기 위해 URL을 생성하는 API입니다.")
+    @Operation(summary = "팀 초대", description = "팀원이 다른 구성원을 초대하기 위해 URL을 생성하는 API입니다.")
     public ResponseEntity<SuccessResponse<InvitationCodeResponse>> inviteTeam(
             @ExistTeam @PathVariable("teamId") Long teamId,
             @RequestBody InvitationCodeRequest request,
@@ -51,7 +53,7 @@ public class TeamController {
     }
 
     @DeleteMapping("/{teamId}/leave")
-    @Operation(summary = "팀 나가기 API", description = "팀원이 본인이 속한 팀에서 나가기 위한 API입니다.")
+    @Operation(summary = "팀 나가기", description = "팀원이 본인이 속한 팀에서 나가기 위한 API입니다.")
     public ResponseEntity<SuccessResponse<LeaveTeamResponse>> leaveTeam(
             @ExistTeam @PathVariable("teamId") Long teamId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
@@ -61,7 +63,7 @@ public class TeamController {
     }
 
     @GetMapping("/invitation")
-    @Operation(summary = "팀 참가하기 API", description = "멤버가 팀에 참가하는 API입니다.")
+    @Operation(summary = "팀 참가", description = "멤버가 팀에 참가하는 API입니다.")
     public ResponseEntity<SuccessResponse<JoinTeamResponse>> joinTeam(
             @RequestParam("code") String code,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
@@ -72,7 +74,7 @@ public class TeamController {
     }
 
     @GetMapping("/{teamId}")
-    @Operation(summary = "다른 팀 불러오기 API", description = "멤버가 다른 팀의 정보를 가지고 오는 API입니다.")
+    @Operation(summary = "팀 전환", description = "멤버가 다른 팀의 정보를 가지고 오는 API입니다.")
     public ResponseEntity<SuccessResponse<GetTeamResponse>> getTeam(
             @ExistTeam @PathVariable("teamId") Long teamId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
@@ -81,8 +83,17 @@ public class TeamController {
         return ResponseFactory.success(response);
     }
 
+    @GetMapping("/members")
+    @Operation(summary = "팀 내의 모든 멤버 조회")
+    public ResponseEntity<SuccessResponse<TeamMemberListResponse>> getTeamMembers(
+         @TeamMember TeamMemberVO teamMember
+    ) {
+        var result = teamQueryService.findTeamMembers(teamMember.getTeamId());
+        return ResponseFactory.success(result);
+    }
+
     @GetMapping("/members/search")
-    @Operation(summary = "팀 내의 멤버 검색하기 API", description = "팀 내의 멤버들을 검색하는 API입니다.")
+    @Operation(summary = "팀 내의 멤버 검색", description = "팀 내의 멤버들을 검색하는 API입니다.")
     public ResponseEntity<SuccessResponse<MentionDTO>> searchMembers(
             @RequestParam("name") @NotBlank(message = "이름은 필수 입력 값입니다.") String name,
             @TeamMember TeamMemberVO teamMember

--- a/yellobook-api/src/main/java/com/yellobook/domains/team/dto/response/TeamMemberListResponse.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/dto/response/TeamMemberListResponse.java
@@ -1,0 +1,11 @@
+package com.yellobook.domains.team.dto.response;
+
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
+
+import java.util.List;
+
+public record TeamMemberListResponse(
+        List<QueryTeamMember> members
+) {
+}
+

--- a/yellobook-api/src/main/java/com/yellobook/domains/team/mapper/TeamMapper.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/mapper/TeamMapper.java
@@ -1,11 +1,14 @@
 package com.yellobook.domains.team.mapper;
 
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
 import com.yellobook.domains.team.dto.request.CreateTeamRequest;
 import com.yellobook.domains.team.dto.response.*;
 import com.yellobook.domains.team.entity.Team;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @Mapper(componentModel = "spring")
@@ -14,10 +17,18 @@ public interface TeamMapper {
 
     @Mapping(source = "id", target = "teamId")
     CreateTeamResponse toCreateTeamResponse(Team team);
+
     LeaveTeamResponse toLeaveTeamResponse(Long teamId);
+
     InvitationCodeResponse toInvitationCodeResponse(String inviteUrl);
+
     @Mapping(source = "id", target = "teamId")
     JoinTeamResponse toJoinTeamResponse(Team team);
+
     @Mapping(source = "id", target = "teamId")
     GetTeamResponse toGetTeamResponse(Team team);
+
+    default TeamMemberListResponse toTeamMemberListResponse(List<QueryTeamMember> members) {
+        return new TeamMemberListResponse(members);
+    }
 }

--- a/yellobook-api/src/main/java/com/yellobook/domains/team/service/TeamQueryService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/service/TeamQueryService.java
@@ -2,6 +2,7 @@ package com.yellobook.domains.team.service;
 
 import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.team.dto.MentionDTO;
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
 import com.yellobook.domains.team.mapper.ParticipantMapper;
 import com.yellobook.domains.team.entity.Participant;
 import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
@@ -23,10 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-@Slf4j
 public class TeamQueryService{
 
     private final TeamRepository teamRepository;
@@ -75,7 +76,6 @@ public class TeamQueryService{
 
     public GetTeamResponse findByTeamId(Long teamId, CustomOAuth2User customOAuth2User){
         //팀 id를 가지고 팀에 대한 정보 가져오기
-
         Long memberId = customOAuth2User.getMemberId();
 
         Participant participant = participantRepository.findByTeamIdAndMemberId(teamId, memberId)
@@ -90,6 +90,12 @@ public class TeamQueryService{
 
         return teamMapper.toGetTeamResponse(team);
     }
+
+    public TeamMemberListResponse findTeamMembers(Long teamId){
+        List<QueryTeamMember> members = teamRepository.findTeamMembers(teamId);
+        return teamMapper.toTeamMemberListResponse(members);
+    }
+
 
     public boolean existsByTeamId(Long teamId) {
         return teamRepository.existsById(teamId);

--- a/yellobook-domain/src/main/java/com/yellobook/domains/order/dto/query/QueryOrder.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/order/dto/query/QueryOrder.java
@@ -13,5 +13,4 @@ public record QueryOrder(
         Integer amount,
         String memo
 ) {
-
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/dto/query/QueryTeamMember.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/dto/query/QueryTeamMember.java
@@ -1,0 +1,7 @@
+package com.yellobook.domains.team.dto.query;
+
+public record QueryTeamMember (
+        Long memberId,
+        String nickname
+){
+}

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantCustomRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantCustomRepository.java
@@ -1,6 +1,7 @@
 package com.yellobook.domains.team.repository;
 
 import com.yellobook.domains.team.dto.query.QueryMemberJoinTeam;
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
 import com.yellobook.domains.team.entity.Participant;
 
 import java.util.List;

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantCustomRepositoryImpl.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantCustomRepositoryImpl.java
@@ -4,29 +4,27 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yellobook.domains.member.entity.QMember;
 import com.yellobook.domains.team.dto.query.QueryMemberJoinTeam;
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
 import com.yellobook.domains.team.entity.Participant;
 import com.yellobook.domains.team.entity.QParticipant;
-import jakarta.persistence.EntityManager;
+import com.yellobook.domains.team.entity.QTeam;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public class ParticipantCustomRepositoryImpl implements ParticipantCustomRepository{
+@RequiredArgsConstructor
+public class ParticipantCustomRepositoryImpl implements ParticipantCustomRepository {
     private final JPAQueryFactory queryFactory;
-
-    public ParticipantCustomRepositoryImpl(EntityManager em){
-        this.queryFactory = new JPAQueryFactory(em);
-    }
-
 
     @Override
     public List<QueryMemberJoinTeam> getMemberJoinTeam(Long memberId) {
         QParticipant participant = QParticipant.participant;
         return queryFactory.select(Projections.constructor(QueryMemberJoinTeam.class,
-                participant.role,
-                participant.team.name.as("teamName")
-                        ))
+                        participant.role,
+                        participant.team.name.as("teamName")
+                ))
                 .from(participant)
                 .where(participant.member.id.eq(memberId))
                 .orderBy(participant.team.name.asc())
@@ -34,13 +32,13 @@ public class ParticipantCustomRepositoryImpl implements ParticipantCustomReposit
     }
 
     @Override
-    public List<Participant> findMentionsByNamePrefix(String prefix, Long teamId){
+    public List<Participant> findMentionsByNamePrefix(String prefix, Long teamId) {
         QMember member = QMember.member;
         QParticipant participant = QParticipant.participant;
 
         return queryFactory.selectFrom(participant)
                 .join(participant.member, member)
-                .where(member.nickname.like(prefix+ "%")
+                .where(member.nickname.like(prefix + "%")
                         .and(participant.team.id.eq(teamId)))
                 .fetch();
     }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/ParticipantRepository.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Optional;
 
 
-@Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long>, ParticipantCustomRepository {
     Optional<Participant> findFirstByMemberIdOrderByCreatedAtAsc(Long memberId);
     List<Participant> findAllByTeamId(Long teamId);

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamCustomRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamCustomRepository.java
@@ -1,0 +1,9 @@
+package com.yellobook.domains.team.repository;
+
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
+
+import java.util.List;
+
+public interface TeamCustomRepository {
+    List<QueryTeamMember> findTeamMembers(Long teamId);
+}

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamCustomRepositoryImpl.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamCustomRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.yellobook.domains.team.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yellobook.domains.member.entity.QMember;
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
+import com.yellobook.domains.team.entity.QParticipant;
+import com.yellobook.domains.team.entity.QTeam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamCustomRepositoryImpl implements  TeamCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<QueryTeamMember> findTeamMembers(Long teamId) {
+        QMember member = QMember.member;
+        QParticipant participant = QParticipant.participant;
+        QTeam team = QTeam.team;
+        return queryFactory
+                .select(
+                        Projections.constructor(QueryTeamMember.class,
+                                member.id.as("memberId"),
+                                member.nickname.as("nickname")
+                        )
+                )
+                .from(team)
+                .join(team, participant.team)
+                .join(participant.member, member)
+                .where(team.id.eq(teamId))
+                .fetch();
+    }
+}

--- a/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/team/repository/TeamRepository.java
@@ -1,12 +1,14 @@
 package com.yellobook.domains.team.repository;
 
+import com.yellobook.domains.team.dto.query.QueryTeamMember;
 import com.yellobook.domains.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
-@Repository
-public interface TeamRepository extends JpaRepository<Team, Long> {
+public interface TeamRepository extends JpaRepository<Team, Long>, TeamCustomRepository {
     Optional<Team> findByName(String name);
+    List<QueryTeamMember> findTeamMembers(Long teamId);
 }


### PR DESCRIPTION
### 작업내용

팀도메인에서 누락된 멤버 조회 엔드포인트 추가했습니다.
FE 요구사항 반영해서 구현하긴 했는데 모든 멤버를 메모리에 올리는게 좋지는 않다고 생각이 들어요 (몇명 제한이 없으니)
추후 리팩토링하면서 무한스크롤 방식으로 바꿔봐요