### PR TITLE
[Chore/YB-427]: 통합테스트 환경 구성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
         uses: appleboy/scp-action@v0.1.7
         with:
           source: "infrastructure/app/docker-compose.yml"
-          target: "~/yellobook/api/docker-compose.yml"
+          target: "~/yellobook/api"
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PEM_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,7 @@ sonar {
 group = 'com.yellobook'
 version = '1.0.0'
 
-/**
- * 루트 build.gradle 에 플러그인 설정을 추가하면 모든 서브프로젝트에 동일한 설정이 적용된다.
- */
+// 루트 build.gradle 에 플러그인 설정을 추가하면 모든 서브프로젝트에 동일한 설정이 적용
 jacoco {
     toolVersion = '0.8.9'
 }
@@ -34,31 +32,15 @@ ext {
         for (qPattern in 'QA'..'QZ') {
             excludes.add('**/${qPattern}*')
         }
+
         excludes.addAll([
-                // main
                 '**/*Application*',
-                // 설정
                 '**/*Config*',
-                // 스프링 시큐리티
-                '**/security/**',
-                // DTO
-                '**/dto/**',
-                // 예외 클래스
-                '**/*Exception*',
-                '**/*ErrorCode*',
-                // 리졸버
-                '**/*Resolver*',
-                // AOP
-                '**/*Aspect*',
-                // 인터셉터, 필터
-                '**/*Interceptor*',
-                '**/*Filter*',
-                // enum
-                '**/enums/**',
-                // mapstruct
-                '**/mapper/**',
-                // 커스텀 애노테이션
-                '**/annotation/**'
+                '**/aop/**',
+                '**/error/**',
+                '**/validation/**',
+                '**/logging/**',
+                '**/response/**'
         ])
 
         return excludes
@@ -105,68 +87,40 @@ subprojects {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
 
-    jacocoTestReport {
-        reports {
-            xml.required = false
-            csv.required = false
-            html.outputLocation = file('build/jacocoTestReportHtml')
-        }
-
-        afterEvaluate  {
-            classDirectories.setFrom(
-                    files(classDirectories.files.collect {
-                        fileTree(dir: it, excludes: rootProject.ext.defineExcludes())
-                    })
-            )
-        }
-
-    }
-
-    tasks.named('test') {
+    test {
         useJUnitPlatform()
-        finalizedBy 'jacocoTestReport'
     }
 }
 
+jacocoTestReport {
+    // 서브프로젝트들의 태스크가 완료된 후 실행되도록 설정
+    dependsOn subprojects.collect {
+        it.tasks.named('check')
+    }
 
+    // 서브프로젝트의 .exec 파일을 포함
+    executionData.from(fileTree(dir: '.', include: '**/build/jacoco/*.exec'))
 
+    // 리포트 생성에서 제외할 경로
+    def excludes = defineExcludes();
 
-tasks.register('jacocoRootReport', JacocoReport) {
+    // 커버리지를 계산할 클래스 파일들의 디렉토리 설정
+    classDirectories.setFrom(files(subprojects.collect {
+        // 서브프로젝트들의 컴파일된 클래스 파일이 저장되는 디렉토리
+        it.sourceSets.main.output
+    }).asFileTree.matching {
+        exclude excludes
+    })
+
     reports {
         xml.required = true
         csv.required = false
         html.outputLocation = file('build/jacocoTestReportHtml')
         xml.outputLocation = file('build/reports/jacoco/test/jacocoTestReport.xml')
     }
-    /**
-     * 태스크 간 의존성을 설정해야 실행 순서를 보장할 수 있다.
-     *
-     * Possible solutions:
-     * 1. Declare task ':yellobook-domains:jacocoTestReport' as an input of ':jacocoRootReport'.
-     * 2. Declare an explicit dependency on ':yellobook-domain:jacocoTestReport' from ':jacocoRootReport' using Task#dependsOn.
-     * 3. Declare an explicit dependency on ':yellobook-domain:jacocoTestReport' from ':jacocoRootReport' using Task#mustRunAfter.
-     *
-     * Gradle 에서 제시한 2번 방법으로 태스크 의존을 설정해 실행 순서를 보장해야 제대로 실행된다.
-     * 각 서브 프로젝트의 jacocoTestReport 태스크가 완료된 후에 실행되도록 한다.
-     * subprojects 에 jacoco 플러그인을 apply 했으므로 jacocoTestReport 와 jacocoTestCoverageVerification 태스크가 자동으로 생성된다.
-     *
-     * Gradle 공식문서 참고
-     * https://docs.gradle.org/current/userguide/jacoco_plugin.html
-     */
-    dependsOn subprojects*.jacocoTestReport
-
-    // 서브 프로젝트의 모든 소스 디렉토리 추가
-    additionalSourceDirs.from = files(subprojects.sourceSets.main.allSource.srcDirs)
-    sourceDirectories.from = files(subprojects.sourceSets.main.allSource.srcDirs)
-    // 모든 서브 프로젝트의 Jacoco 실행 데이터 파일을 포함
-    executionData.from = fileTree(dir: '.', include: '**/build/jacoco/test.exec')
-
-    // 서브 프로젝트의 클래스 디렉토리를 파일 트리로 생성하고, excludes 에 해당하는 패턴을 제외
-    classDirectories.from = files(subprojects.sourceSets.main.output).asFileTree.matching {
-        exclude rootProject.ext.defineExcludes()
-    }
 }
 
+check.dependsOn jacocoTestReport
 
 if (project == rootProject) {
     bootJar {
@@ -174,6 +128,3 @@ if (project == rootProject) {
     }
 }
 
-tasks.named('check') {
-    finalizedBy 'jacocoRootReport'
-}

--- a/yellobook-api/build.gradle
+++ b/yellobook-api/build.gradle
@@ -1,3 +1,18 @@
+sourceSets {
+    integrationTest {
+        java.srcDir "$projectDir/src/integration-test/java"
+        resources.srcDir "$projectDir/src/integration-test/resources"
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom implementation
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
     implementation project(":yellobook-domain")
     implementation project(":yellobook-common")
@@ -29,8 +44,6 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 }
 
-processResources.dependsOn('copyConfig')
-
 // application*.yml 설정파일 복사
 tasks.register('copyConfig', Copy) {
     from '../Config/yellobook-api/'
@@ -38,11 +51,25 @@ tasks.register('copyConfig', Copy) {
     into 'src/main/resources'
 }
 
+tasks.register('integrationTest', Test) {
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    useJUnitPlatform()
+
+    // test 태스크가 없다면 실행되지 않는다.
+    mustRunAfter test
+}
+
+processResources.dependsOn('copyConfig')
+
+check.dependsOn integrationTest, test
+
 bootJar {
     enabled = true
 }
 
-// 일반 jar 파일 생성 비활성화
 jar {
     enabled = false
 }
+
+

--- a/yellobook-api/src/main/java/com/yellobook/common/aop/TeamAdminOnlyAspect.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/aop/TeamAdminOnlyAspect.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class TeamAdminOnlyAspect {
     RedisTeamService redisTeamService;
 
-    @Before("@annotation(com.yellobook.common.annotation.TeamAdminOnly)")
+    @Before("@annotation(com.yellobook.common.aop.annotation.TeamAdminOnly)")
     public void checkIsTeamAdmin(JoinPoint joinPoint) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         var principal = (CustomOAuth2User) authentication.getPrincipal();

--- a/yellobook-api/src/main/java/com/yellobook/common/aop/TeamOrdererOnlyAspect.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/aop/TeamOrdererOnlyAspect.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class TeamOrdererOnlyAspect {
     RedisTeamService redisTeamService;
 
-    @Before("@annotation(com.yellobook.common.annotation.TeamOrdererOnly)")
+    @Before("@annotation(com.yellobook.common.aop.annotation.TeamOrdererOnly)")
     public void checkIsTeamAdmin(JoinPoint joinPoint) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         var principal = (CustomOAuth2User) authentication.getPrincipal();

--- a/yellobook-api/src/main/java/com/yellobook/common/aop/annotation/TeamAdminOnly.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/aop/annotation/TeamAdminOnly.java
@@ -1,14 +1,11 @@
-package com.yellobook.common.annotation;
-
-import io.swagger.v3.oas.annotations.Parameter;
+package com.yellobook.common.aop.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Parameter(hidden = true)
-@Target(ElementType.PARAMETER)
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface TeamMember {
+public @interface TeamAdminOnly {
 }

--- a/yellobook-api/src/main/java/com/yellobook/common/aop/annotation/TeamOrdererOnly.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/aop/annotation/TeamOrdererOnly.java
@@ -1,4 +1,4 @@
-package com.yellobook.common.annotation;
+package com.yellobook.common.aop.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/yellobook-api/src/main/java/com/yellobook/common/resolver/TeamMemberArgumentResolver.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/resolver/TeamMemberArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.yellobook.common.resolver;
 
-import com.yellobook.common.annotation.TeamMember;
+import com.yellobook.common.resolver.annotation.TeamMember;
 import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.yellobook.domains.auth.service.RedisTeamService;

--- a/yellobook-api/src/main/java/com/yellobook/common/resolver/annotation/TeamMember.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/resolver/annotation/TeamMember.java
@@ -1,11 +1,14 @@
-package com.yellobook.common.annotation;
+package com.yellobook.common.resolver.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Parameter(hidden = true)
+@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface TeamAdminOnly {
+public @interface TeamMember {
 }

--- a/yellobook-api/src/main/java/com/yellobook/common/validation/annotation/ExistInform.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/validation/annotation/ExistInform.java
@@ -1,6 +1,6 @@
-package com.yellobook.common.annotation;
+package com.yellobook.common.validation.annotation;
 
-import com.yellobook.common.validator.ExistInformValidator;
+import com.yellobook.common.validation.validator.ExistInformValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 

--- a/yellobook-api/src/main/java/com/yellobook/common/validation/annotation/ExistOrder.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/validation/annotation/ExistOrder.java
@@ -1,4 +1,4 @@
-package com.yellobook.common.annotation;
+package com.yellobook.common.validation.annotation;
 
 
 import com.yellobook.common.validation.validator.ExistOrderValidator;

--- a/yellobook-api/src/main/java/com/yellobook/common/validation/validator/ExistInformValidator.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/validation/validator/ExistInformValidator.java
@@ -1,6 +1,6 @@
-package com.yellobook.common.validator;
+package com.yellobook.common.validation.validator;
 
-import com.yellobook.common.annotation.ExistInform;
+import com.yellobook.common.validation.annotation.ExistInform;
 import com.yellobook.domains.inform.repository.InformRepository;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/yellobook-api/src/main/java/com/yellobook/common/validation/validator/ExistOrderValidator.java
+++ b/yellobook-api/src/main/java/com/yellobook/common/validation/validator/ExistOrderValidator.java
@@ -1,6 +1,6 @@
 package com.yellobook.common.validation.validator;
 
-import com.yellobook.common.annotation.ExistOrder;
+import com.yellobook.common.validation.annotation.ExistOrder;
 import com.yellobook.domains.order.service.OrderQueryService;
 import com.yellobook.error.code.OrderErrorCode;
 import jakarta.validation.ConstraintValidator;

--- a/yellobook-api/src/main/java/com/yellobook/domains/auth/controller/AuthController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/auth/controller/AuthController.java
@@ -16,7 +16,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -29,9 +28,6 @@ import java.io.IOException;
 @RequestMapping("/api/v1/auth")
 @Tag(name = "\uD83D\uDD11 인증", description = "Auth API")
 public class AuthController {
-
-    @Value("${frontend.auth-redirect-url}")
-    private String authRedirectUrl;
 
     private final AuthService authService;
     private final CookieService cookieService;
@@ -68,14 +64,4 @@ public class AuthController {
         authService.logout(oAuth2User.getMemberId(), accessToken);
         return ResponseFactory.noContent();
     }
-
-    @Operation(summary = "회원 탈퇴")
-    @PatchMapping("/deactivate")
-    public ResponseEntity<SuccessResponse<String>> deactivate(
-            @AuthenticationPrincipal CustomOAuth2User oAuth2User
-    ) {
-//        authService.deactivate(oAuth2User);
-        return null;
-    }
-
 }

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/controller/InformController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/controller/InformController.java
@@ -1,6 +1,6 @@
 package com.yellobook.domains.inform.controller;
 
-import com.yellobook.common.annotation.ExistInform;
+import com.yellobook.common.validation.annotation.ExistInform;
 import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.yellobook.domains.inform.dto.request.CreateInformCommentRequest;
 import com.yellobook.domains.inform.dto.request.CreateInformRequest;

--- a/yellobook-api/src/main/java/com/yellobook/domains/inventory/controller/InventoryController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inventory/controller/InventoryController.java
@@ -1,6 +1,6 @@
 package com.yellobook.domains.inventory.controller;
 
-import com.yellobook.common.annotation.TeamMember;
+import com.yellobook.common.resolver.annotation.TeamMember;
 import com.yellobook.common.validation.annotation.ExistInventory;
 import com.yellobook.common.validation.annotation.ExistProduct;
 import com.yellobook.common.vo.TeamMemberVO;

--- a/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.yellobook.domains.member.controller;
 
-import com.yellobook.common.resolver.annotation.TeamMember;
-import com.yellobook.common.vo.TeamMemberVO;
+
+import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
 import com.yellobook.domains.member.service.MemberCommandService;
 import com.yellobook.domains.member.service.MemberQueryService;
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,10 +29,10 @@ public class MemberController {
     @GetMapping("/profile")
     @Operation(summary = "마이프로필 조회", description = "로그인한 멤버의 마이프로필 조회 API")
     public ResponseEntity<SuccessResponse<ProfileResponse>> getMemberProfile(
-            @TeamMember TeamMemberVO teamMember
+            @AuthenticationPrincipal CustomOAuth2User user
     ) {
-        var result = memberQueryService.getMemberProfile(teamMember.getMemberId());
-        return ResponseFactory.success(result);
+        ProfileResponse response = memberQueryService.getMemberProfile(user.getMemberId());
+        return ResponseFactory.success(response);
     }
 
 

--- a/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.yellobook.domains.member.controller;
 
-import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
+import com.yellobook.common.resolver.annotation.TeamMember;
+import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
 import com.yellobook.domains.member.service.MemberCommandService;
 import com.yellobook.domains.member.service.MemberQueryService;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,12 +27,11 @@ public class MemberController {
     @GetMapping("/profile")
     @Operation(summary = "마이프로필 조회", description = "로그인한 멤버의 마이프로필 조회 API")
     public ResponseEntity<SuccessResponse<ProfileResponse>> getMemberProfile(
-            @AuthenticationPrincipal CustomOAuth2User user
+            @TeamMember TeamMemberVO teamMember
     ) {
-        ProfileResponse response = memberQueryService.getMemberProfile(user.getMemberId());
-        return ResponseFactory.success(response);
+        var result = memberQueryService.getMemberProfile(teamMember.getMemberId());
+        return ResponseFactory.success(result);
     }
-
 
 
 //    @PatchMapping("/deactivate")

--- a/yellobook-api/src/main/java/com/yellobook/domains/order/controller/OrderController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.yellobook.domains.order.controller;
 
-import com.yellobook.common.annotation.ExistOrder;
-import com.yellobook.common.annotation.TeamMember;
+import com.yellobook.common.validation.annotation.ExistOrder;
+import com.yellobook.common.resolver.annotation.TeamMember;
 import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.order.dto.request.AddOrderCommentRequest;
 import com.yellobook.domains.order.dto.request.MakeOrderRequest;

--- a/yellobook-api/src/main/java/com/yellobook/domains/schedule/controller/ScheduleController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/schedule/controller/ScheduleController.java
@@ -1,6 +1,6 @@
 package com.yellobook.domains.schedule.controller;
 
-import com.yellobook.common.annotation.TeamMember;
+import com.yellobook.common.resolver.annotation.TeamMember;
 import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.schedule.dto.request.DailyParam;
 import com.yellobook.domains.schedule.dto.request.MonthlyParam;

--- a/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
@@ -1,6 +1,6 @@
 package com.yellobook.domains.team.controller;
 
-import com.yellobook.common.annotation.TeamMember;
+import com.yellobook.common.resolver.annotation.TeamMember;
 import com.yellobook.common.validation.annotation.ExistTeam;
 import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;

--- a/yellobook-api/src/test/java/com/yellobook/domains/member/controller/MemberControllerTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import com.yellobook.domains.member.service.MemberCommandService;
 import com.yellobook.domains.member.service.MemberQueryService;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Disabled
 @WebMvcTest(MemberController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)

--- a/yellobook-api/src/test/java/com/yellobook/domains/member/controller/MemberControllerTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/member/controller/MemberControllerTest.java
@@ -10,7 +10,6 @@ import com.yellobook.domains.member.service.MemberCommandService;
 import com.yellobook.domains.member.service.MemberQueryService;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +33,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Disabled
 @WebMvcTest(MemberController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## 📄 Work Description
<strong>Jira Ticket : `YB-427`</strong>
 

스크럼 안건으로 나온 통합테스트 방법론에 대한 글을 참고해 프로젝트에 도입해봤습니다. 

sourceSets 에 통합태스트를 위한 integration-test 경로를 추가하고, jacoco 커버리지 리포트에 반영되도록 구성했습니다.

기존에는 root build.gradle 에서 subprojects 에 공통적으로 jacoco 에 대한 설정을 적용해 하위모듈들에 적용되게끔 작성했었습니다.

finalizedBy 를 이용해서 test 태스크가 완료된 후 후속작업으로 jacocoTestReport 태스크가 실행될 수 있도록 구성했는데요, 여기서 문제가 생겼습니다.

```java
 subprojects {
   ...
	 jacocoTestReport {
        reports {
            xml.required = false
            csv.required = false
            html.outputLocation = file('build/jacocoTestReportHtml')
        }

        afterEvaluate  {
            classDirectories.setFrom(
                    files(classDirectories.files.collect {
                        fileTree(dir: it, excludes: rootProject.ext.defineExcludes())
                    })
            )
        }

    }

    test {
        useJUnitPlatform()
        finalizedBy 'jacocoTestReport'
    }
}
```

통합테스트를 추가하고, 별도의 `sourceSet` 으로 지정했기 때문에  jacoco 의 커버리지 리포트를 생성할때 test 뿐만 아니라 integration-test 도 완료된 후 리포트가 생성되도록 보장해야 하는데, 통합테스트에 관련된 sourceSet 은 api 모듈에만 존재하기 때문에 subprojects 로 공통설정을 해줄 수 없게 됩니다. 

따라서, 커버리지 리포트를 작성하는 태스크를 모듈별 build.gradle 로 분리할까 생각했는데 통합된 리포트만 보는 경우가 대부분이므로, 모듈별로는 리포트를 생성하지 않고, 루트에서 통합리포트만 생성하도록 변경했습니다.

![image](https://github.com/user-attachments/assets/365bae10-984a-4741-8a1e-3c512ffa4be9)

공식문서의 기본 태스크 의존관계 그래프를 보면 build 는 check 에 의존하고 check 는 test 에 의존하므로, 루트에서 모든 서브프로젝트의 build 가 끝난 뒤 리포트를 작성합니다. 이후 check 가 jacocoTestReport 에 의존하게끔 해서 루트 그래들의 build 가 마무리되었을 때 리포트가 생기는걸 보장했습니다.

**아래는 리포트 생성시 이용한 방법을 정리한 내용이에요**

서브모듈은 apply 로 jacoco 플러그인을 받으므로 실행시 Test 태스크에 해당하는 jacoco exec 가 생깁니다.  (integrationTest 도 Test 를 상속하므로  exec 가 생기게 됩니다.)

```java
// Test 를 상속받아 정의
tasks.register('integrationTest', Test) {
		...
}
```

exec 파일에는 커버된 라인 등 커버리지 데이터가 포함되어 있습니다. jacoco 가 이 `.exec` 파일을 읽어서 어떤 클래스가 얼마나 커버되었는지를 계산하고, 이를 기반으로 XML, HTML 등의 형식으로 리포트를 생성합니다.

root build.gradle 에서는 `classDirectories` 에 분석할 클래스파일의 경로를 설정해줍니다. 서브프로젝트들의 build/class/java/main 디렉토리를 수집하고 excludes 로 분석 대상에서 제외할 경로를 지정했습니다.

```java
  // 커버리지를 계산할 클래스 파일들의 디렉토리 설정
classDirectories.setFrom(files(subprojects.collect {
    // 서브프로젝트들의 컴파일된 클래스 파일이 저장되는 디렉토리
    it.sourceSets.main.output
}).asFileTree.matching {
    exclude excludes
})
```

이렇게 설정해주면 jacoco 가 위에서 언급한 `.exec` 파일과 클래스 파일을 결합하여 통합 커버리지 리포트를 만들어줍니다.

<br/>

## 💬 To Reviewers

common 디렉토리에 aop, resolver, validation 에 쓰이는 애노테이션들이 뒤섞여 존재하길래 각각 디렉토리에 재배치해두었습니다. 확인 한번씩 부탁드려요




 


<br/>

## 🔗 Reference
https://docs.gradle.org/current/userguide/build_lifecycle.html

https://velog.io/@mu1616/javagradle%EB%8B%A8%EC%9C%84-%ED%85%8C%EC%8A%A4%ED%8A%B8unit-test%EC%99%80-%ED%86%B5%ED%95%A9-%ED%85%8C%EC%8A%A4%ED%8A%B8integration-test-%ED%99%98%EA%B2%BD-%EB%B6%84%EB%A6%AC



