### PR TITLE
[Chore/YB-432] testFixtures 도입

### DIFF
--- a/yellobook-api/build.gradle
+++ b/yellobook-api/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    //mapStruct
+    // mapStruct
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
@@ -42,6 +42,9 @@ dependencies {
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'com.h2database:h2'
+
+    // testFixtures
+    testImplementation(testFixtures(project(":yellobook-domain")))
 }
 
 // application*.yml 설정파일 복사

--- a/yellobook-domain/build.gradle
+++ b/yellobook-domain/build.gradle
@@ -1,3 +1,13 @@
+plugins {
+    id 'java-library'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'jacoco'
+    id "java-test-fixtures"
+    id "maven-publish"
+}
+
+
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -15,6 +25,9 @@ dependencies {
 
     // h2
     testRuntimeOnly 'com.h2database:h2'
+
+    // testFixtures 에 JUnit 의존성 추가
+    testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api'
 }
 
 processResources.dependsOn('copyConfig')

--- a/yellobook-domain/src/testFixtures/java/fixture/InformFixture.java
+++ b/yellobook-domain/src/testFixtures/java/fixture/InformFixture.java
@@ -1,0 +1,44 @@
+package fixture;
+
+import com.yellobook.domains.inform.entity.Inform;
+import com.yellobook.domains.inform.entity.InformMention;
+import com.yellobook.domains.member.entity.Member;
+import com.yellobook.domains.team.entity.Team;
+import support.ReflectionUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class InformFixture {
+    private static final String INFORM_TITLE = "공지 및 일정";
+    private static final String INFORM_CONTENT = "내용";
+    private static final LocalDate INFORM_DATE = LocalDate.now();
+    private static final LocalDateTime INFORM_TIMESTAMP = LocalDateTime.now();
+
+    public static Inform createInform(Team team, Member member) {
+        return createInform(team, member, INFORM_DATE, INFORM_TITLE, INFORM_CONTENT, INFORM_TIMESTAMP);
+    }
+
+    public static Inform createInform(Team team, Member member, LocalDate date) {
+        return createInform(team, member, date, INFORM_TITLE, INFORM_CONTENT, INFORM_TIMESTAMP);
+    }
+
+    public static Inform createInform(Team team, Member member, LocalDate date, String title, String content, LocalDateTime timestamp) {
+        Inform inform = Inform.builder()
+                .title(title)
+                .content(content)
+                .date(date)
+                .team(team)
+                .member(member)
+                .build();
+        ReflectionUtils.setBaseTimeEntityFields(inform, timestamp);
+        return inform;
+    }
+
+    public static InformMention createInformMention(Inform inform, Member member) throws Exception {
+        return InformMention.builder()
+                .inform(inform)
+                .member(member)
+                .build();
+    }
+}

--- a/yellobook-domain/src/testFixtures/java/fixture/InventoryFixture.java
+++ b/yellobook-domain/src/testFixtures/java/fixture/InventoryFixture.java
@@ -1,0 +1,50 @@
+package fixture;
+
+import com.yellobook.domains.inventory.entity.Inventory;
+import com.yellobook.domains.inventory.entity.Product;
+import com.yellobook.domains.team.entity.Team;
+
+public class InventoryFixture {
+    // 재고
+    private static final String INVENTORY_TITLE = "2024년 08월 06일 재고현황";
+
+    // 상품
+    private static final String PRODUCT_NAME = "제품";
+    private static final String PRODUCT_SUBPRODUCT = "서브제품";
+    private static final int PRODUCT_SKU = 1;
+    private static final int PRODUCT_PURCHASE_PRICE = 100;
+    private static final int PRODUCT_SALE_PRICE = 150;
+    private static final int PRODUCT_AMOUNT = 100;
+
+    public static Inventory createInventory(Team team) {
+        return createInventory(INVENTORY_TITLE, team);
+    }
+
+    public static Inventory createInventory(String title, Team team) {
+        return Inventory.builder()
+                .title(title)
+                .team(team)
+                .build();
+    }
+
+    public static Product createProduct(Inventory inventory) {
+        return createProduct(PRODUCT_NAME, PRODUCT_SUBPRODUCT, PRODUCT_SKU, PRODUCT_PURCHASE_PRICE, PRODUCT_SALE_PRICE, PRODUCT_AMOUNT, inventory);
+    }
+
+    public static Product createProduct(String name, String subProduct, Inventory inventory) {
+        return createProduct(name, subProduct, PRODUCT_SKU, PRODUCT_PURCHASE_PRICE, PRODUCT_SALE_PRICE, PRODUCT_AMOUNT, inventory);
+    }
+
+    public static Product createProduct(String name, String subProduct, int sku, int purchasePrice, int salePrice, int amount, Inventory inventory) {
+        return Product.builder()
+                .name(name)
+                .subProduct(subProduct)
+                .sku(sku)
+                .purchasePrice(purchasePrice)
+                .salePrice(salePrice)
+                .amount(amount)
+                .inventory(inventory)
+                .build();
+    }
+}
+

--- a/yellobook-domain/src/testFixtures/java/fixture/MemberFixture.java
+++ b/yellobook-domain/src/testFixtures/java/fixture/MemberFixture.java
@@ -1,0 +1,34 @@
+package fixture;
+
+import com.yellobook.common.enums.MemberRole;
+import com.yellobook.domains.member.entity.Member;
+import support.ReflectionUtils;
+
+import java.time.LocalDateTime;
+
+public class MemberFixture {
+    private static final String MEMBER_NICKNAME = "사용자";
+    private static final String MEMBER_EMAIL = "example@gmail.com";
+    private static final String MEMBER_PROFILE_IMAGE = "profile.png";
+    private static final MemberRole MEMBER_ROLE = MemberRole.USER;
+    private static final Boolean MEMBER_ALLOWANCE = true;
+    private static final LocalDateTime MEMBER_TIMESTAMP = LocalDateTime.now();
+
+
+    public static Member createMember() {
+        LocalDateTime now = LocalDateTime.now();
+        return createMember(MEMBER_NICKNAME, MEMBER_EMAIL, MEMBER_PROFILE_IMAGE, MEMBER_ROLE, MEMBER_ALLOWANCE, MEMBER_TIMESTAMP);
+    }
+
+    public static Member createMember(String nickname, String email, String profileImage, MemberRole role, Boolean allowance, LocalDateTime timestamp) {
+        Member member = Member.builder()
+                .nickname(nickname)
+                .email(email)
+                .profileImage(profileImage)
+                .role(role)
+                .allowance(allowance)
+                .build();
+        ReflectionUtils.setBaseTimeEntityFields(member, timestamp);
+        return member;
+    }
+}

--- a/yellobook-domain/src/testFixtures/java/fixture/OrderFixture.java
+++ b/yellobook-domain/src/testFixtures/java/fixture/OrderFixture.java
@@ -1,0 +1,50 @@
+package fixture;
+
+import com.yellobook.common.enums.OrderStatus;
+import com.yellobook.domains.inventory.entity.Product;
+import com.yellobook.domains.order.entity.Order;
+import com.yellobook.domains.member.entity.Member;
+import com.yellobook.domains.order.entity.OrderMention;
+import com.yellobook.domains.team.entity.Team;
+import support.ReflectionUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class OrderFixture {
+    private static final int ORDER_VIEW = 1;
+    private static final String ORDER_MEMO = "메모";
+    private static final OrderStatus ORDER_STATUS = OrderStatus.CONFIRMED;
+    private static final int ORDER_AMOUNT = 1;
+    private static final LocalDate ORDER_DATE = LocalDate.now();
+    private static final LocalDateTime ORDER_TIMESTAMP = LocalDateTime.now();
+
+    public static Order createOrder(Team team, Member member, Product product, LocalDate orderDate) {
+        return createOrder(team, member, product, orderDate, ORDER_VIEW, ORDER_MEMO, ORDER_STATUS, ORDER_AMOUNT, ORDER_TIMESTAMP);
+    }
+
+    public static Order createOrder(Team team, Member member, Product product, LocalDate orderDate, int view, String memo, OrderStatus status, int amount, LocalDateTime timestamp) {
+        Order order = Order.builder()
+                .view(view)
+                .memo(memo)
+                .date(orderDate)
+                .orderStatus(status)
+                .orderAmount(amount)
+                .team(team)
+                .member(member)
+                .product(product)
+                .build();
+        ReflectionUtils.setBaseTimeEntityFields(order, timestamp);
+        return order;
+    }
+
+    // 주문 언급
+    public static OrderMention createOrderMention(Order order, Member member) {
+        return OrderMention.builder()
+                .order(order)
+                .member(member)
+                .build();
+    }
+
+}
+

--- a/yellobook-domain/src/testFixtures/java/fixture/TeamFixture.java
+++ b/yellobook-domain/src/testFixtures/java/fixture/TeamFixture.java
@@ -1,0 +1,38 @@
+package fixture;
+
+import com.yellobook.domains.team.entity.Team;
+import com.yellobook.domains.team.entity.Participant;
+import com.yellobook.domains.member.entity.Member;
+import com.yellobook.common.enums.MemberTeamRole;
+import support.ReflectionUtils;
+
+import java.time.LocalDateTime;
+
+public class TeamFixture {
+    private static final String TEAM_NAME = "팀1";
+    private static final String TEAM_PHONE_NUMBER = "010-1234-5678";
+    private static final String TEAM_ADDRESS = "서울특별시";
+    private static final LocalDateTime TEAM_TIMESTAMP = LocalDateTime.now();
+
+    public static Team createTeam() {
+        return createTeam(TEAM_NAME, TEAM_PHONE_NUMBER, TEAM_ADDRESS, TEAM_TIMESTAMP);
+    }
+
+    public static Team createTeam(String name, String phoneNumber, String address, LocalDateTime timestamp) {
+        Team team = Team.builder()
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .address(address)
+                .build();
+        ReflectionUtils.setBaseTimeEntityFields(team, timestamp);
+        return team;
+    }
+
+    public static Participant createParticipant(Team team, Member member, MemberTeamRole role) {
+        return Participant.builder()
+                .team(team)
+                .member(member)
+                .role(role)
+                .build();
+    }
+}

--- a/yellobook-domain/src/testFixtures/java/support/ReflectionUtils.java
+++ b/yellobook-domain/src/testFixtures/java/support/ReflectionUtils.java
@@ -1,0 +1,30 @@
+package support;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+public class ReflectionUtils {
+
+    /**
+     * 엔티티의 createdAt과 updatedAt 필드를 설정
+     * @param entity 엔티티 인스턴스
+     * @param timestamp 설정할 시간
+     */
+    public static void setBaseTimeEntityFields(Object entity, LocalDateTime timestamp) {
+        try {
+            setField(entity, "createdAt", timestamp);
+            setField(entity, "updatedAt", timestamp);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Assertions.fail("리플렉션 필드 설정 중 예외 발생: " + e.getMessage());
+        }
+    }
+
+    // 리플렉션으로 필드값 설정
+    private static void setField(Object entity, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
+        Field field = entity.getClass().getSuperclass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(entity, value);
+    }
+}


### PR DESCRIPTION
## 📄 Work Description
<strong>Jira Ticket : `YB-432`</strong>
 
기존 방식은 test 에 엔티티 생성 로직 등 테스트마다 중복된 코드가 많을 뿐더러 이를 support 로 뽑는다 해도 서로 다른 모듈일 경우 클래스를 import 해 사용할 수 없었습니다.

이를 해결하고자  java-test-fixtures 플러그인을 도입해 중복 코드를 줄일 수 있도록 세팅을 진행했습니다.

간단히 특정 도메인 객체를 생성해야하는 작업만 추가해두었고, 각 도메인마다 모듈별, 테스트별 중복되는 부분이 있다면 `XXFixture`클래스에 정의하면 api 모듈, domain 모듈에서 모두 끌어다 쓸 수 있습니다.

현재 도메인 객체 생성에는 모든 필드를 바탕으로 생성하는 메소드가 기본적으로 작성되어 있습니다. 

필요시 오버로딩 해서 테스트에 적합한 형태로 엔티티를 생성하시면 될 것 같습니다.

![image](https://github.com/user-attachments/assets/c6f16c7e-5880-4861-b45b-14f3bc00c20d)


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->

자바에서는 타입스크립트와 다르게 옵셔널 파라미터를 쓸 수 있는 방법이 없어 오버로딩으로 해결하는 방법을 생각했습니다.

더 나은 방법이 있다면 리뷰 부탁드려요!
 


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)

[[Gradle] Multi Module에서 testFixtures를 이용하여 테스트 코드 중복 줄이기](https://medium.com/@jojiapp/gradle-multi-module%EC%97%90%EC%84%9C-testfixtures%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-%EC%A4%91%EB%B3%B5-%EC%A4%84%EC%9D%B4%EA%B8%B0-3a4737f574f)

[Gradle Test Fixture 사용해서 테스트 중복코드 줄이기](https://bottom-to-top.tistory.com/58)

