### PR TITLE
[Refactor/YB-493] 팀 도메인 TeamMember 적용

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/controller/TeamController.java
@@ -36,7 +36,7 @@ public class TeamController {
             @RequestBody CreateTeamRequest request,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        CreateTeamResponse response = teamCommandService.createTeam(request, customOAuth2User);
+        CreateTeamResponse response = teamCommandService.createTeam(request, customOAuth2User.getMemberId());
         return ResponseFactory.created(response);
     }
 
@@ -45,9 +45,9 @@ public class TeamController {
     public ResponseEntity<SuccessResponse<InvitationCodeResponse>> inviteTeam(
             @ExistTeam @PathVariable("teamId") Long teamId,
             @RequestBody InvitationCodeRequest request,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+            @TeamMember TeamMemberVO teamMember
     ) {
-        InvitationCodeResponse response = teamQueryService.makeInvitationCode(teamId, request, customOAuth2User);
+        InvitationCodeResponse response = teamQueryService.makeInvitationCode(teamId, request, teamMember.getMemberId());
         return ResponseFactory.created(response);
     }
 
@@ -55,9 +55,9 @@ public class TeamController {
     @Operation(summary = "팀 나가기", description = "팀원이 본인이 속한 팀에서 나가기 위한 API입니다.")
     public ResponseEntity<Void> leaveTeam(
             @ExistTeam @PathVariable("teamId") Long teamId,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+            @TeamMember TeamMemberVO teamMember
     ){
-        teamCommandService.leaveTeam(teamId, customOAuth2User);
+        teamCommandService.leaveTeam(teamId, teamMember.getMemberId());
         return ResponseFactory.noContent();
     }
 
@@ -68,7 +68,7 @@ public class TeamController {
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             HttpServletResponse res
     ){
-        JoinTeamResponse response = teamCommandService.joinTeam(customOAuth2User, code);
+        JoinTeamResponse response = teamCommandService.joinTeam(customOAuth2User.getMemberId(), code);
         return ResponseFactory.success(response);
     }
 
@@ -78,7 +78,7 @@ public class TeamController {
             @ExistTeam @PathVariable("teamId") Long teamId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ){
-        GetTeamResponse response = teamQueryService.findByTeamId(teamId, customOAuth2User);
+        GetTeamResponse response = teamQueryService.findByTeamId(teamId, customOAuth2User.getMemberId());
         return ResponseFactory.success(response);
     }
 
@@ -97,7 +97,7 @@ public class TeamController {
             @RequestParam("name") @NotBlank(message = "이름은 필수 입력 값입니다.") String name,
             @TeamMember TeamMemberVO teamMember
     ){
-        TeamMemberListResponse response = teamQueryService.searchParticipants(teamMember, name);
+        TeamMemberListResponse response = teamQueryService.searchParticipants(teamMember.getTeamId(), name);
         return ResponseFactory.success(response);
     }
 }

--- a/yellobook-api/src/main/java/com/yellobook/domains/team/service/TeamCommandService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/team/service/TeamCommandService.java
@@ -1,7 +1,6 @@
 package com.yellobook.domains.team.service;
 
 import com.yellobook.domains.auth.dto.InvitationResponse;
-import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
 import com.yellobook.domains.auth.service.RedisTeamService;
 import com.yellobook.domains.team.dto.request.*;
 import com.yellobook.domains.team.dto.response.*;
@@ -21,8 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -36,11 +33,11 @@ public class TeamCommandService {
     private final ParticipantMapper participantMapper;
     private final RedisTeamService redisService;
 
-    public CreateTeamResponse createTeam(CreateTeamRequest request, CustomOAuth2User customOAuth2User){
+    public CreateTeamResponse createTeam(CreateTeamRequest request, Long memberId){
 
-        Member member = memberRepository.findById(customOAuth2User.getMemberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
-                    log.warn("Member {} not found.", customOAuth2User.getMemberId());
+                    log.warn("Member {} not found.", memberId);
                     return new CustomException(TeamErrorCode.MEMBER_NOT_FOUND);
                 });
         if(teamRepository.findByName(request.name()).isPresent()){
@@ -61,9 +58,7 @@ public class TeamCommandService {
         }
     }
 
-    public void leaveTeam(Long teamId, CustomOAuth2User customOAuth2User) {
-        Long memberId = customOAuth2User.getMemberId();
-
+    public void leaveTeam(Long teamId, Long memberId) {
         Participant participant = participantRepository.findByTeamIdAndMemberId(teamId, memberId)
                 .orElseThrow(() -> {
                     log.warn("Participant not found for Member ID = {} and Team ID = {}", memberId, teamId);
@@ -83,12 +78,11 @@ public class TeamCommandService {
                 });
     }
 
-    public JoinTeamResponse joinTeam(CustomOAuth2User customOAuth2User, String code) {
+    public JoinTeamResponse joinTeam(Long memberId, String code) {
 
         InvitationResponse invitationData = redisService.getInvitationInfo(code);
         Long teamId = invitationData.getTeamId();
         MemberTeamRole role = invitationData.getRole();
-        Long memberId = customOAuth2User.getMemberId();
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {

--- a/yellobook-api/src/test/java/com/yellobook/domains/team/service/TeamCommandServiceTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/team/service/TeamCommandServiceTest.java
@@ -94,7 +94,7 @@ public class TeamCommandServiceTest {
                 when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
 
                 exception = assertThrows(CustomException.class, () -> {
-                    teamCommandService.createTeam(duplicateNameRequest, customOAuth2User);
+                    teamCommandService.createTeam(duplicateNameRequest, customOAuth2User.getMemberId());
                 });
             }
 
@@ -127,7 +127,7 @@ public class TeamCommandServiceTest {
                 when(teamMapper.toTeam(validRequest)).thenReturn(team);
                 when(teamMapper.toCreateTeamResponse(any(Team.class))).thenReturn(new CreateTeamResponse(1L, LocalDateTime.now()));
 
-                response = teamCommandService.createTeam(validRequest, customOAuth2User);
+                response = teamCommandService.createTeam(validRequest, customOAuth2User.getMemberId());
             }
 
             @Test
@@ -164,7 +164,7 @@ public class TeamCommandServiceTest {
                 when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
 
                 exception = assertThrows(CustomException.class, () -> {
-                    teamCommandService.joinTeam(customOAuth2User, code);
+                    teamCommandService.joinTeam(customOAuth2User.getMemberId(), code);
                 });
             }
 
@@ -195,7 +195,7 @@ public class TeamCommandServiceTest {
                 when(participantRepository.findByTeamIdAndRole(team.getId(), MemberTeamRole.ADMIN)).thenReturn(Optional.of(participant));
 
                 exception = assertThrows(CustomException.class, () -> {
-                    teamCommandService.joinTeam(customOAuth2User, adminInvitationCode);
+                    teamCommandService.joinTeam(customOAuth2User.getMemberId(), adminInvitationCode);
                 });
             }
 
@@ -225,7 +225,7 @@ public class TeamCommandServiceTest {
                 when(teamRepository.findById(anyLong())).thenReturn(Optional.empty());
 
                 exception = assertThrows(CustomException.class, () -> {
-                    teamCommandService.joinTeam(customOAuth2User, notExistTeamCode);
+                    teamCommandService.joinTeam(customOAuth2User.getMemberId(), notExistTeamCode);
                 });
             }
 
@@ -258,7 +258,7 @@ public class TeamCommandServiceTest {
                 when(participantRepository.findByTeamIdAndMemberId(belongTeamId, 1L)).thenReturn(Optional.of(participant));
 
                 exception = assertThrows(CustomException.class, () -> {
-                    teamCommandService.joinTeam(customOAuth2User, belongTeamCode);
+                    teamCommandService.joinTeam(customOAuth2User.getMemberId(), belongTeamCode);
                 });
             }
 
@@ -289,7 +289,7 @@ public class TeamCommandServiceTest {
                 when(participantMapper.toParticipant(MemberTeamRole.ADMIN, team, member)).thenReturn(participant);
                 when(teamMapper.toJoinTeamResponse(team)).thenReturn(new JoinTeamResponse(team.getId()));
 
-                response = teamCommandService.joinTeam(customOAuth2User, code);
+                response = teamCommandService.joinTeam(customOAuth2User.getMemberId(), code);
             }
 
             @Test
@@ -330,7 +330,7 @@ public class TeamCommandServiceTest {
                 when(participantRepository.findByTeamIdAndMemberId(teamId, memberId)).thenReturn(Optional.empty());
 
                 exception = assertThrows(
-                        CustomException.class, () -> teamCommandService.leaveTeam(teamId, customOAuth2User));
+                        CustomException.class, () -> teamCommandService.leaveTeam(teamId, member.getId()));
             }
 
             @Test
@@ -356,7 +356,7 @@ public class TeamCommandServiceTest {
                 when(participantRepository.findByTeamIdAndMemberId(teamId, memberId)).thenReturn(Optional.of(participant));
                 when(participantRepository.findFirstByMemberIdOrderByCreatedAtAsc(memberId)).thenReturn(Optional.of(participant));
 
-                teamCommandService.leaveTeam(teamId, customOAuth2User);
+                teamCommandService.leaveTeam(teamId, memberId);
             }
 
             @Test

--- a/yellobook-api/src/test/java/com/yellobook/domains/team/service/TeamQueryServiceTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/team/service/TeamQueryServiceTest.java
@@ -52,7 +52,6 @@ public class TeamQueryServiceTest {
 
     @InjectMocks
     private TeamQueryService teamQueryService;
-
     private CustomOAuth2User customOAuth2User;
 
     private Member member;
@@ -88,7 +87,7 @@ public class TeamQueryServiceTest {
                 when(participantRepository.findByTeamIdAndMemberId(team.getId(), member.getId())).thenReturn(Optional.empty());
 
                 exception = assertThrows(
-                        CustomException.class, () -> teamQueryService.makeInvitationCode(team.getId(), request, customOAuth2User));
+                        CustomException.class, () -> teamQueryService.makeInvitationCode(team.getId(), request, 1L));
 
             }
 
@@ -126,7 +125,7 @@ public class TeamQueryServiceTest {
                         .thenReturn(Optional.of(adminPar));
 
                 exception = assertThrows(
-                        CustomException.class, () -> teamQueryService.makeInvitationCode(teamId, request, customOAuth2User));
+                        CustomException.class, () -> teamQueryService.makeInvitationCode(teamId, request, memberId));
             }
 
             @Test
@@ -155,7 +154,7 @@ public class TeamQueryServiceTest {
                 when(teamMapper.toInvitationCodeResponse(anyString()))
                         .thenReturn(new InvitationCodeResponse("http://invitation-url")); // 응답 매핑
 
-                response = teamQueryService.makeInvitationCode(team.getId(), request, customOAuth2User);
+                response = teamQueryService.makeInvitationCode(team.getId(), request, member.getId());
             }
 
             @Test
@@ -248,7 +247,7 @@ public class TeamQueryServiceTest {
                 when(participantRepository.findMentionsByNamePrefix(prefix, team.getId())).thenReturn(members);
                 when(teamMapper.toTeamMemberListResponse(members)).thenReturn(new TeamMemberListResponse(members));
 
-                res = teamQueryService.searchParticipants(teamMember, prefix);
+                res = teamQueryService.searchParticipants(teamMember.getTeamId(), prefix);
             }
 
             @Test
@@ -276,7 +275,7 @@ public class TeamQueryServiceTest {
                 when(participantRepository.findMentionsByNamePrefix(prefix, team.getId())).thenReturn(members);
                 when(teamMapper.toTeamMemberListResponse(members)).thenReturn(new TeamMemberListResponse(members));
 
-                res = teamQueryService.searchParticipants(teamMember, prefix);
+                res = teamQueryService.searchParticipants(teamMember.getTeamId(), prefix);
             }
 
             @Test
@@ -300,7 +299,7 @@ public class TeamQueryServiceTest {
                         .thenReturn(Optional.empty());
 
                 exception = assertThrows(
-                        CustomException.class, () -> teamQueryService.findByTeamId(team.getId(), customOAuth2User));
+                        CustomException.class, () -> teamQueryService.findByTeamId(team.getId(), customOAuth2User.getMemberId()));
             }
 
             @Test

--- a/yellobook-api/src/test/java/com/yellobook/domains/team/util/SecurityUtil.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/team/util/SecurityUtil.java
@@ -1,0 +1,21 @@
+package com.yellobook.domains.team.util;
+
+import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    public static void setAuthentication(CustomOAuth2User customOAuth2User) {
+        // Authentication 객체 생성
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        customOAuth2User,
+                        null,
+                        customOAuth2User.getAuthorities()
+                );
+
+        // SecurityContextHolder에 설정
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB-493 `</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. (작업 내용 간단 요약)
작업한 부분 설명 및 코드와 이미지 첨부
팀 도메인에서 컨트롤러의 경우, 팀에 속한 멤버들만 접근할 수 있는 것들,
예를 들어 팀 나가기 및 팀 초대의 경우
CustomOAuth2User가 아닌 TeamMember로 수정하는 작업을 거쳤습니다.

이로 인해 TeamControllerUnitTest를 수정하였는데요.
이전에 컨트롤러에서 @AuthenticationPrincipal로 CustomOAuth2User를 받았었고
이를 검증할 때 any()와 같은 것으로 테스트를 했었지만,
이번에 리팩토링을 거치면서 CustomOAuth2User를 사용하는 메소드에서 기존과 같은 작업을 할 때 NPE가 발생하였습니다.

따라서 이를 해결하기 위해 확인해본 결과 
CustomOAuth2User가 SecurityContextHolder에 담기지 않았기 때문에 발생하는 에러임을 알게 되었습니다.

따라서 저는 애노테이션을 새로 만드는 방법도 있었지만
SecurityContextHolder에 잘 담을 수 있는 Util을 만든 후,
BeforeEach단계에서 세팅을 하였습니다.

![image](https://github.com/user-attachments/assets/e5061c84-280e-4a24-92b0-2bd034fbb09c)


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->
애노테이션을 만드는 방법도 좋을 수 있을 것 같긴 한데,
의견을 말씀해주시면 감사하겠습니다!

<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
https://k3068.tistory.com/96
