### PR TITLE
[Chore/YB-524]: codecov 리포트 생성을 cd 파이프라인으로 이동

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,16 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Gradle 빌드
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
+
+      - name: CodeCoverage 업로드
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: true
+          verbose: true
+        continue-on-error: false
 
       - name: 도커허브 접속을 위해 로그인
         uses: docker/login-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Jacoco CI Test
 on:
   # CI 는 PR 시에만 동작
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   build:
@@ -53,12 +53,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info
-
-      - name: CodeCoverage 업로드
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./build/reports/jacoco/test/jacocoTestReport.xml
-          fail_ci_if_error: true
-          verbose: true
-        continue-on-error: false


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB-524`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

기존에는 CI 파이프라인에서 SonarCloud 와 CodeCov  가 모두 동작했습니다.

CI 동작 -> 빌드, 테스트 완료시 PR 에서 확인 -> merge 시 cd 파이프라인 동작 / 테스트 생략 후 배포

### 문제점 발생

오늘 @jorippppong 님이 보내주신 것처럼 develop 에 커버리지 리포트가 반영되지 않는 문제점이 발견되었습니다.

**로컬 report, 브랜치 커버리지는 반영되었음** 

![image](https://github.com/user-attachments/assets/2ec90b3d-5ce7-4f2d-b3c6-e1325b3ff064)

![image](https://github.com/user-attachments/assets/00a43ee2-b90b-4c21-9d9f-245ca2d073a7)


**develop 브랜치의 커버리지는 업데이트 되지 않음**

![image](https://github.com/user-attachments/assets/44e962f3-c365-4d6a-ac6d-7ca011e879b9)


따라서 CD 파이프라인에서 테스트를 포함시켜서 빌드를 하도록 변경했습니다.

CI 에서는 SonarCloud 가 연동되어있어서 커버리지 확인이 가능하기 때문에 CodeCov 업로드는 제외했습니다.

정리하면
 
PR -> test -> SonarCloud 정적분석 (테스트커버리지 확인가능) -> merge -> develop CD -> CodeCov 업로드 및 뱃지 갱신 

입니다.

