### PR TITLE
[Hotfix/YB-534] 공지 조회 API 수정

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/dto/response/GetInformResponse.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/dto/response/GetInformResponse.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 
 @Builder
 public record GetInformResponse(
+        @Schema(description = "가지고 오는 글의 작성자")
+        String author,
         @Schema(description = "가지고 오는 글의 제목")
         String title,
         @Schema(description = "가지고 오는 글에 있는 메모")

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/mapper/InformMapper.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/mapper/InformMapper.java
@@ -30,6 +30,7 @@ public interface InformMapper {
     @Mapping(target = "memo", source = "inform.content")
     @Mapping(target = "view", source = "inform.view")
     @Mapping(target = "date", source = "inform.date")
+    @Mapping(target = "author", source = "inform.member.nickname")
     GetInformResponse toGetInformResponseDTO(Inform inform, List<InformComment> comments, List<Member> members);
 
     default List<CommentItem> mapComments(List<InformComment> comments) {

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/mapper/InformMapper.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/mapper/InformMapper.java
@@ -31,7 +31,8 @@ public interface InformMapper {
     @Mapping(target = "view", source = "inform.view")
     @Mapping(target = "date", source = "inform.date")
     @Mapping(target = "author", source = "inform.member.nickname")
-    GetInformResponse toGetInformResponseDTO(Inform inform, List<InformComment> comments, List<Member> members);
+    GetInformResponse toGetInformResponseDTO(Inform inform, List<InformComment> comments, List<Member> mentions,
+                                             List<Member> members);
 
     default List<CommentItem> mapComments(List<InformComment> comments) {
         return comments.stream()

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformCommandService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformCommandService.java
@@ -103,7 +103,7 @@ public class InformCommandService {
         Inform inform = informRepository.findById(informId)
                 .get();
 
-        List<InformMention> mentions = informMentionRepository.findByInformId(informId);
+        List<InformMention> mentions = informMentionRepository.findAllByInformId(informId);
 
         Long writerId = inform.getMember()
                 .getId();

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformQueryService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformQueryService.java
@@ -32,9 +32,10 @@ public class InformQueryService {
         Long writerId = inform.getMember()
                 .getId();
 
-        // 공지및 일정의 언급들
-        List<InformMention> mentions = informMentionRepository.findByInformId(informId);
-        // 공지 및 일정에 달린 댓글들
+        // 공지의 언급들
+        List<InformMention> mentions = informMentionRepository.findAllByInformId(informId);
+
+        // 공지에 달린 댓글들
         List<InformComment> comments = inform.getComments();
 
         List<Member> mentionedMembers = new ArrayList<>();
@@ -46,7 +47,7 @@ public class InformQueryService {
                         .equals(memberId));
 
         if (memberId.equals(writerId) || isMentioned) {
-            return informMapper.toGetInformResponseDTO(inform, comments, mentionedMembers);
+            return informMapper.toGetInformResponseDTO(inform, comments, mentionedMembers, mentionedMembers);
         } else {
             throw new CustomException(InformErrorCode.NOT_MENTIONED);
         }

--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformQueryService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/service/InformQueryService.java
@@ -28,7 +28,7 @@ public class InformQueryService {
 
     public GetInformResponse getInformById(Long memberId, Long informId) {
         Inform inform = informRepository.findById(informId)
-                .get();
+                .orElseThrow(() -> new CustomException(InformErrorCode.INFORM_NOT_FOUND));
         Long writerId = inform.getMember()
                 .getId();
 

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inform/repository/InformMentionRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inform/repository/InformMentionRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InformMentionRepository extends JpaRepository<InformMention, Long> {
-    List<InformMention> findByInformId(Long informId);
+    List<InformMention> findAllByInformId(Long informId);
 }

--- a/yellobook-domain/src/test/java/com/yellobook/domains/inform/InformMentionRepositoryTest.java
+++ b/yellobook-domain/src/test/java/com/yellobook/domains/inform/InformMentionRepositoryTest.java
@@ -110,7 +110,7 @@ public class InformMentionRepositoryTest {
 
     @Nested
     @DisplayName("findByInformId 메소드는")
-    class Describe_FindByInformId {
+    class Describe_FindAllByInformId {
 
         @Nested
         @DisplayName("해당하는 inform 안에 mention 이 존재하는 경우")
@@ -145,7 +145,7 @@ public class InformMentionRepositoryTest {
             @Test
             @DisplayName("InformMention list를 반환한다.")
             void it_returns_inform_mention_list() {
-                mentions = informMentionRepository.findByInformId(informId);
+                mentions = informMentionRepository.findAllByInformId(informId);
 
                 assertThat(mentions).isNotEmpty();
             }
@@ -172,7 +172,7 @@ public class InformMentionRepositoryTest {
                 inform = createInform(team, member);
                 em.persist(inform);
                 informId = inform.getId();
-                mentions = informMentionRepository.findByInformId(informId);
+                mentions = informMentionRepository.findAllByInformId(informId);
             }
 
             @Test
@@ -191,7 +191,7 @@ public class InformMentionRepositoryTest {
 
             @BeforeEach
             void setUp() {
-                mentions = informMentionRepository.findByInformId(nonExistentInformId);
+                mentions = informMentionRepository.findAllByInformId(nonExistentInformId);
             }
 
             @Test


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB- 534`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. (작업 내용 간단 요약)
작업한 부분 설명 및 코드와 이미지 첨부
InformQueryService 부분에서 GetInform 메소드를 실행할 때, 작성자와 멘션 멤버들을 보여주지 않는 에러가 있었습니다.
따라서 이 부분에 대해 수정작업을 진행하였습니다.
작성자는 inform에 저장된 member를 가져왔고, 멘션 멤버는 코드 내에 mentionedMembers를 통해 반환하도록 수정하였습니다.

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


최대한 빨리 하려고 하다보니 효율적이지 못한 코드일 가능성이 높습니다.
따라서 해당 부분에 대해 피드백하실 부분이 있으시다면 피드백 주시면 감사하겠습니다!

<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)

