### PR TITLE
[Hotfix/YB-538]: InformController Unit Test 수정

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/inform/controller/InformController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inform/controller/InformController.java
@@ -55,7 +55,7 @@ public class InformController {
     }
 
     @GetMapping("/{informId}")
-    @Operation(summary = "공지목록 조회", description = "등록된 공지를 조회하는 API 입니다.")
+    @Operation(summary = "공지 조회", description = "등록된 공지를 조회하는 API 입니다.")
     public ResponseEntity<SuccessResponse<GetInformResponse>> getInform(
             @ExistInform @PathVariable("informId") Long informId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User

--- a/yellobook-api/src/test/java/com/yellobook/domains/inform/controller/InformControllerTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/inform/controller/InformControllerTest.java
@@ -158,7 +158,7 @@ public class InformControllerTest {
             @BeforeEach
             void setUp() throws Exception {
                 informId = 1L;
-                response = new GetInformResponse("test", "test", List.of(), 10, List.of(), LocalDate.now());
+                response = new GetInformResponse("test", "test", "test", List.of(), 10, List.of(), LocalDate.now());
 
                 member = createMember();
                 OAuth2UserDTO oAuth2UserDTO = OAuth2UserDTO.from(member);


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB-538 `</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. (작업 내용 간단 요약)
작업한 부분 설명 및 코드와 이미지 첨부
Test code 수정을 안해서 build가 제대로 안된 사실을 우상님이 말씀하셨는데,
정신이 없어서.. 그냥 올려버렸다보니 이런 일이 생겼네요..
테스트 코드 돌아갈 수 있도록 수정했습니다.
다음부터 정신 차리겠습니다..

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)

