### PR TITLE
[Fix/YB-577]: 제품 CUD 시 재고 현황의 마지막 업데이트 일시 수정

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -42,4 +42,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-report
-          path: ./yellobook-domain/build/reports/tests/test/index.html
+          path: ./yellobook-domain/build/reports/tests/test/

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,45 @@
+name: Test Report
+
+on:
+  # CI 는 PR 시에만 동작
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 리포지토리 checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # 서브모듈을 포함해서 checkout
+          submodules: recursive
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Gradle 빌드
+        run: ./gradlew clean build
+        continue-on-error: true  # 테스트가 실패하더라도 다음 단계로 넘어감
+
+      - name: Test Report 제작
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-report
+          path: ./yellobook-domain/build/reports/tests/test/index.html

--- a/yellobook-domain/src/main/java/com/yellobook/domains/common/entity/BaseEntity.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/common/entity/BaseEntity.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -22,6 +22,6 @@ public abstract class BaseEntity {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/entity/Inventory.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/entity/Inventory.java
@@ -51,7 +51,4 @@ public class Inventory extends BaseEntity {
         this.view = 0;
     }
 
-//    public void increaseView() {
-//        this.view += 1;
-//    }
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/entity/Inventory.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/entity/Inventory.java
@@ -51,7 +51,7 @@ public class Inventory extends BaseEntity {
         this.view = 0;
     }
 
-    public void increaseView() {
-        this.view += 1;
-    }
+//    public void increaseView() {
+//        this.view += 1;
+//    }
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
@@ -17,4 +17,9 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Inv
     @Query("update Inventory i set i.updatedAt = :now where i.id = :id")
     void updateUpdatedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
 
+    @Modifying
+    @Query("update Inventory i set i.view = i.view+1 where i.id = :id")
+    void increaseView(@Param("id") Long id);
+
+
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
@@ -1,11 +1,20 @@
 package com.yellobook.domains.inventory.repository;
 
 import com.yellobook.domains.inventory.entity.Inventory;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InventoryRepository extends JpaRepository<Inventory, Long>, InventoryRepositoryCustom {
     Optional<Inventory> findFirstByTeamIdOrderByCreatedAtDesc(Long teamId);
+
+    @Modifying
+    @Query("update Inventory i set i.updatedAt = :now where i.id = :id")
+    LocalDateTime updateUpdatedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
+
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
@@ -15,6 +15,6 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Inv
 
     @Modifying
     @Query("update Inventory i set i.updatedAt = :now where i.id = :id")
-    LocalDateTime updateUpdatedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
+    void updateUpdatedAt(@Param("id") Long id, @Param("now") LocalDateTime now);
 
 }

--- a/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/inventory/repository/InventoryRepository.java
@@ -21,5 +21,4 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Inv
     @Query("update Inventory i set i.view = i.view+1 where i.id = :id")
     void increaseView(@Param("id") Long id);
 
-
 }

--- a/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
+++ b/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
@@ -252,7 +252,51 @@ public class InventoryRepositoryTest extends RepositoryTest {
                 assertThat(updatedInventory).isNotNull();
                 assertThat(updatedInventory.getUpdatedAt()).isEqualTo(updatedAt);
             }
+        }
+    }
 
+    @Nested
+    @DisplayName("increaseView 메소드는")
+    class Describe_IncreaseView {
+        @Nested
+        @DisplayName("재고 id가 주어지면")
+        class Context_inventory_id_given {
+            Inventory inventory;
+
+            @BeforeEach
+            void setUpContext() {
+                Team team = em.persist(createTeam("팀1"));
+                inventory = createInventory(team);
+                em.persist(inventory);
+            }
+
+            @Test
+            @DisplayName("view를 1 증가한다.")
+            void it_increases_view() {
+                inventoryRepository.increaseView(inventory.getId());
+                em.flush();
+                em.clear();
+
+                Inventory updatedInventory = inventoryRepository.findById(inventory.getId())
+                        .orElse(null);
+
+                assertThat(updatedInventory).isNotNull();
+                assertThat(updatedInventory.getView()).isEqualTo(inventory.getView() + 1);
+            }
+
+            @Test
+            @DisplayName("updatedAt는 변경 없이 이전과 동일하다.")
+            void it_remains_same_updatedAt() {
+                inventoryRepository.increaseView(inventory.getId());
+                em.flush();
+                em.clear();
+
+                Inventory updatedInventory = inventoryRepository.findById(inventory.getId())
+                        .orElse(null);
+
+                assertThat(updatedInventory).isNotNull();
+                assertThat(updatedInventory.getUpdatedAt()).isEqualTo(inventory.getUpdatedAt());
+            }
         }
     }
 

--- a/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
+++ b/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
@@ -287,6 +287,7 @@ public class InventoryRepositoryTest extends RepositoryTest {
             @Test
             @DisplayName("updatedAt는 변경 없이 이전과 동일하다.")
             void it_remains_same_updatedAt() {
+                LocalDateTime oldUpdatedAt = inventory.getUpdatedAt();
                 inventoryRepository.increaseView(inventory.getId());
                 em.flush();
                 em.clear();
@@ -295,7 +296,8 @@ public class InventoryRepositoryTest extends RepositoryTest {
                         .orElse(null);
 
                 assertThat(updatedInventory).isNotNull();
-                assertThat(updatedInventory.getUpdatedAt()).isEqualTo(inventory.getUpdatedAt());
+                // JPQL auditing 우회 명시
+                assertThat(updatedInventory.getUpdatedAt()).isEqualTo(oldUpdatedAt);
             }
         }
     }

--- a/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
+++ b/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
@@ -12,6 +12,7 @@ import com.yellobook.domains.inventory.entity.Product;
 import com.yellobook.domains.team.entity.Team;
 import com.yellobook.support.RepositoryTest;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -289,15 +290,15 @@ public class InventoryRepositoryTest extends RepositoryTest {
             void it_remains_same_updatedAt() {
                 LocalDateTime oldUpdatedAt = inventory.getUpdatedAt();
                 inventoryRepository.increaseView(inventory.getId());
-                em.flush();
-                em.clear();
 
                 Inventory updatedInventory = inventoryRepository.findById(inventory.getId())
                         .orElse(null);
 
                 assertThat(updatedInventory).isNotNull();
                 // JPQL auditing 우회 명시
-                assertThat(updatedInventory.getUpdatedAt()).isEqualTo(oldUpdatedAt);
+                assertThat(updatedInventory.getUpdatedAt()
+                        .truncatedTo(ChronoUnit.SECONDS))
+                        .isEqualTo(oldUpdatedAt.truncatedTo(ChronoUnit.SECONDS));
             }
         }
     }

--- a/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
+++ b/yellobook-domain/src/test/java/com/yellobook/domains/inventory/repository/InventoryRepositoryTest.java
@@ -11,6 +11,7 @@ import com.yellobook.domains.inventory.entity.Inventory;
 import com.yellobook.domains.inventory.entity.Product;
 import com.yellobook.domains.team.entity.Team;
 import com.yellobook.support.RepositoryTest;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -221,5 +222,39 @@ public class InventoryRepositoryTest extends RepositoryTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("updateUpdatedAt 메소드는")
+    class Describe_UpdateUpdatedAt {
+        @Nested
+        @DisplayName("재고 id와 updatedAt 날짜가 주어지면")
+        class Context_inventory_id_and_updatedAt_given {
+            Inventory inventory;
+            LocalDateTime updatedAt = LocalDateTime.of(2024, 11, 4, 12, 0);
+
+            @BeforeEach
+            void setUpContext() {
+                Team team = em.persist(createTeam("팀1"));
+                inventory = createInventory(team);
+                em.persist(inventory);
+            }
+
+            @Test
+            @DisplayName("주어진 updatedAt 날짜로 변경한다.")
+            void it_updates_updatedAt() {
+                inventoryRepository.updateUpdatedAt(inventory.getId(), updatedAt);
+                em.flush();
+                em.clear();
+
+                Inventory updatedInventory = inventoryRepository.findById(inventory.getId())
+                        .orElse(null);
+
+                assertThat(updatedInventory).isNotNull();
+                assertThat(updatedInventory.getUpdatedAt()).isEqualTo(updatedAt);
+            }
+
+        }
+    }
+
 
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB- 577`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 제품 CUD 시 재고 현황의 마지막 업데이트 일시(updatedAt) 수정
<img width="365" alt="KakaoTalk_Snapshot_20241104_150902" src="https://github.com/user-attachments/assets/edc02ca6-8c63-4ade-836c-03f5aad6e608">

yelloBook 전체 단톡방에서 "재고 현황의 마지막 업데이트 일시"의 변경 기준의 무엇인지 물어봐주셨다. 재고 현황에 포함되어 있는 제품들이 CUD (제품 수량 수정, 제품 삭제, 제품 추가) 될때, 재고 현황의 마지막 업데이트 일시가 수정되고, 이를 반영해 코드를 수정했다. 

기존의 updatedAt의 어노테이션이 `@LastModifiedBy`로 되어 있어서, 이를 `@LastModifiedDate`로 수정했다. 그리고 updatedAt 필드는 abstract class인 BaseEntity의 필드이고 Jpa가 Auditing 후에 변경하기 때문에, dirty checking으로는 필드값을 변경하기 애매했다. 따라서 JPQL를 사용하여 수동으로 updatedAt 필드를 수정하는 메소드를 만들고 단위 테스트를 작성했다. 


#### 2. 재고현황의 view 증가하는 API 수정
기존의 view 증가 코드에서는 dirty checking를 사용하여 view를 update하는 쿼리가 자동으로 발생하도록 코드를 작성했다. 이 경우 view가 증가하면 inventory의 updated도 같이 변경된다는 문제가 있다. 
```java
/**
* 재고 조회수 증가
*/
public void increaseInventoryView(Long inventoryId, TeamMemberVO teamMember) {
      ParticipantUtil.forbidViewer(teamMember.getRole());
      
      Inventory inventory = inventoryRepository.findById(inventoryId)
            .orElseThrow(() -> new CustomException(InventoryErrorCode.INVENTORY_NOT_FOUND));
      inventory.increaseView();
}
```

JPQL를 활용한 연산은 영속성 컨텍스트와 독립적으로 실행된다. 즉, 해당 쿼리가 실행될 때 JPA는 해당 엔티티의 상태를 감지하지 않으므로, Auditing 기능이 작동하지 않는다. 이를 활용하여 코드를 수정 하고 단위 테스트를 작성했다. 
```java
@Modifying
@Query("update Inventory i set i.view = i.view+1 where i.id = :id")
void increaseView(@Param("id") Long id);
```

<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)
https://velog.io/@sdsd0908/JPA-%EB%B2%8C%ED%81%AC-%EC%BF%BC%EB%A6%AC%EC%97%B0%EC%82%B0-%EC%82%AC%EC%9A%A9%EB%B2%95-em.flush
