### PR TITLE
[Feature/YB-586]: 사용자가 현재 위치한 팀 정보 반환 로직 구현

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.yellobook.domains.member.controller;
 
 
+import com.yellobook.common.resolver.annotation.TeamMember;
+import com.yellobook.common.vo.TeamMemberVO;
 import com.yellobook.domains.auth.security.oauth2.dto.CustomOAuth2User;
+import com.yellobook.domains.member.dto.response.CurrentTeamResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
-import com.yellobook.domains.member.service.MemberCommandService;
 import com.yellobook.domains.member.service.MemberQueryService;
 import com.yellobook.response.ResponseFactory;
 import com.yellobook.response.SuccessResponse;
@@ -23,15 +25,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberQueryService memberQueryService;
-    private final MemberCommandService memberCommandService;
 
     @GetMapping("/profile")
-    @Operation(summary = "마이프로필 조회", description = "로그인한 멤버의 마이프로필 조회 API")
+    @Operation(summary = "마이프로필 조회", description = "로그인한 사용자의 마이프로필 조회 API")
     public ResponseEntity<SuccessResponse<ProfileResponse>> getMemberProfile(
             @AuthenticationPrincipal CustomOAuth2User user
     ) {
-        ProfileResponse response = memberQueryService.getMemberProfile(user.getMemberId());
-        return ResponseFactory.success(response);
+        var result = memberQueryService.getMemberProfile(user.getMemberId());
+        return ResponseFactory.success(result);
+    }
+
+    @GetMapping("/teams/current")
+    @Operation(summary = "사용자가 현재 위치한 팀 조회", description = "로그인한 사용자가 현재 위치한 팀 정보를 반환하는 API")
+    public ResponseEntity<SuccessResponse<CurrentTeamResponse>> getMemberCurrentTeam(
+            @TeamMember TeamMemberVO teamMember
+    ) {
+        var result = memberQueryService.getMemberCurrentTeam(teamMember.getTeamId());
+        return ResponseFactory.success(result);
     }
 
 //    @PatchMapping("/deactivate")

--- a/yellobook-api/src/main/java/com/yellobook/domains/member/dto/response/CurrentTeamResponse.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/dto/response/CurrentTeamResponse.java
@@ -1,0 +1,14 @@
+package com.yellobook.domains.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record CurrentTeamResponse(
+        @Schema(description = "팀 Id")
+        Long teamId,
+
+        @Schema(description = "팀 이름")
+        String teamName
+) {
+}

--- a/yellobook-api/src/main/java/com/yellobook/domains/member/mapper/MemberMapper.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/mapper/MemberMapper.java
@@ -1,10 +1,12 @@
 package com.yellobook.domains.member.mapper;
 
+import com.yellobook.domains.member.dto.response.CurrentTeamResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse.ParticipantInfo;
 import com.yellobook.domains.member.dto.response.TermAllowanceResponse;
 import com.yellobook.domains.member.entity.Member;
 import com.yellobook.domains.team.dto.query.QueryMemberJoinTeam;
+import com.yellobook.domains.team.entity.Team;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,5 +30,7 @@ public interface MemberMapper {
                 .build();
     }
 
-
+    @Mapping(source = "id", target = "teamId")
+    @Mapping(source = "name", target = "teamName")
+    CurrentTeamResponse toCurrentTeamResponse(Team team);
 }

--- a/yellobook-api/src/main/java/com/yellobook/domains/member/service/MemberQueryService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/member/service/MemberQueryService.java
@@ -1,12 +1,15 @@
 package com.yellobook.domains.member.service;
 
+import com.yellobook.domains.member.dto.response.CurrentTeamResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse.ParticipantInfo;
 import com.yellobook.domains.member.dto.response.TermAllowanceResponse;
 import com.yellobook.domains.member.entity.Member;
 import com.yellobook.domains.member.mapper.MemberMapper;
 import com.yellobook.domains.member.repository.MemberRepository;
+import com.yellobook.domains.team.entity.Team;
 import com.yellobook.domains.team.repository.ParticipantRepository;
+import com.yellobook.domains.team.repository.TeamRepository;
 import com.yellobook.error.code.MemberErrorCode;
 import com.yellobook.error.exception.CustomException;
 import java.util.List;
@@ -21,6 +24,7 @@ public class MemberQueryService {
 
     private final MemberRepository memberRepository;
     private final ParticipantRepository participantRepository;
+    private final TeamRepository teamRepository;
     private final MemberMapper memberMapper;
 
     public ProfileResponse getMemberProfile(Long memberId) {
@@ -40,4 +44,10 @@ public class MemberQueryService {
         return memberMapper.toAllowanceResponseDTO(allowed);
     }
 
+    public CurrentTeamResponse getMemberCurrentTeam(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() ->
+                        new CustomException(MemberErrorCode.MEMBER_TEAM_NOT_FOUND));
+        return memberMapper.toCurrentTeamResponse(team);
+    }
 }

--- a/yellobook-api/src/test/java/com/yellobook/domains/member/service/MemberQueryServiceTest.java
+++ b/yellobook-api/src/test/java/com/yellobook/domains/member/service/MemberQueryServiceTest.java
@@ -2,24 +2,31 @@ package com.yellobook.domains.member.service;
 
 import static com.yellobook.domains.member.dto.response.ProfileResponse.ParticipantInfo;
 import static fixture.MemberFixture.createMember;
+import static fixture.TeamFixture.createTeam;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yellobook.common.enums.TeamMemberRole;
+import com.yellobook.domains.member.dto.response.CurrentTeamResponse;
 import com.yellobook.domains.member.dto.response.ProfileResponse;
 import com.yellobook.domains.member.dto.response.TermAllowanceResponse;
 import com.yellobook.domains.member.entity.Member;
 import com.yellobook.domains.member.mapper.MemberMapper;
 import com.yellobook.domains.member.repository.MemberRepository;
 import com.yellobook.domains.team.dto.query.QueryMemberJoinTeam;
+import com.yellobook.domains.team.entity.Team;
 import com.yellobook.domains.team.repository.ParticipantRepository;
+import com.yellobook.domains.team.repository.TeamRepository;
+import com.yellobook.error.code.MemberErrorCode;
 import com.yellobook.error.exception.CustomException;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +43,10 @@ class MemberQueryServiceTest {
     private MemberQueryService memberQueryService;
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
+
     @Mock
     private ParticipantRepository participantRepository;
     @Mock
@@ -123,7 +134,7 @@ class MemberQueryServiceTest {
             @Test
             @DisplayName("예외를 반환한다.")
             void it_throws_exception() {
-                Assertions.assertThrows(CustomException.class, () -> memberQueryService.getMemberProfile(memberId));
+                assertThrows(CustomException.class, () -> memberQueryService.getMemberProfile(memberId));
                 verify(memberRepository).findById(memberId);
             }
         }
@@ -171,11 +182,66 @@ class MemberQueryServiceTest {
             }
 
             @Test
-            @DisplayName("예외를 반환한다.")
+            @DisplayName("CustomException 이 발생해야 한다.")
             void it_throws_exception() {
-                Assertions.assertThrows(CustomException.class, () -> memberQueryService.getAllowanceById(memberId));
+                assertThrows(CustomException.class, () -> memberQueryService.getAllowanceById(memberId));
                 verify(memberRepository).findById(memberId);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMemberCurrentTeam 메소드는")
+    class Describe_GetMemberCurrentTeam {
+        @Nested
+        @DisplayName("존재하는 팀이라면")
+        class Context_with_team {
+            final Long teamId = 99L;
+            final String teamName = "옐로북팀";
+
+            @BeforeEach
+            void setUpContext() throws NoSuchFieldException, IllegalAccessException {
+                CurrentTeamResponse response = CurrentTeamResponse.builder()
+                        .teamId(teamId)
+                        .teamName(teamName)
+                        .build();
+                Team team = createTeam(teamName);
+                Field teamIdField = Team.class.getDeclaredField("id");
+                teamIdField.setAccessible(true);
+                teamIdField.set(team, teamId);
+
+                when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+                when(memberMapper.toCurrentTeamResponse(team)).thenReturn(response);
+            }
+
+            @Test
+            @DisplayName("사용자가 현재 위치한 팀Id 와 팀 이름을 반환한다.")
+            void it_returns_current_teamId_and_teamName() {
+                var response = memberQueryService.getMemberCurrentTeam(teamId);
+                assertThat(response.teamId()).isEqualTo(teamId);
+                assertThat(response.teamName()).isEqualTo(teamName);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 팀이라면")
+        class Context_with_non_exist_team {
+            @BeforeEach
+            void setUpContext() {
+                when(teamRepository.findById(anyLong())).thenReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("CustomException이 발생해야 한다.")
+            void it_throws_exception() {
+                CustomException exception = assertThrows(
+                        CustomException.class,
+                        () -> memberQueryService.getMemberCurrentTeam(1L)
+                );
+
+                assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_TEAM_NOT_FOUND);
+            }
+
         }
     }
 

--- a/yellobook-common/src/main/java/com/yellobook/error/code/MemberErrorCode.java
+++ b/yellobook-common/src/main/java/com/yellobook/error/code/MemberErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MemberErrorCode implements ErrorCode {
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "해당 사용자는 존재하지 않습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "해당 사용자는 존재하지 않습니다."),
+    MEMBER_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-002", "사용자가 위치한 팀 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB- 586` </strong>

프론트엔드 요청에 따라 사용자가 현재 위치한 팀 정보 반환 로직을 반환하는 엔드포인트를 추가로 만들었습니다.
- 관련된 컨트롤러, 서비스 작성
- 사용자가 위치한 팀을 찾지 못할 경우 반환하는 에러코드 Enum 추가
- 추가된 Controller, Service 유닛 테스트 작성

사용자가 중심이므로 team 도메인이 아닌 member 부분에 추가했습니다.
 

 

