### PR TITLE
[Fix/YB-593]: 제품 삭제 API 수정

### DIFF
--- a/yellobook-api/src/main/java/com/yellobook/domains/inventory/service/InventoryCommandService.java
+++ b/yellobook-api/src/main/java/com/yellobook/domains/inventory/service/InventoryCommandService.java
@@ -14,6 +14,7 @@ import com.yellobook.domains.inventory.mapper.ProductMapper;
 import com.yellobook.domains.inventory.repository.InventoryRepository;
 import com.yellobook.domains.inventory.repository.ProductRepository;
 import com.yellobook.domains.inventory.utils.ExcelReadUtil;
+import com.yellobook.domains.order.repository.OrderRepository;
 import com.yellobook.domains.team.entity.Team;
 import com.yellobook.domains.team.repository.TeamRepository;
 import com.yellobook.error.code.FileErrorCode;
@@ -39,6 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class InventoryCommandService {
     private final InventoryRepository inventoryRepository;
     private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
     private final TeamRepository teamRepository;
     private final ProductMapper productMapper;
     private final InventoryMapper inventoryMapper;
@@ -93,6 +95,10 @@ public class InventoryCommandService {
 
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(InventoryErrorCode.PRODUCT_NOT_FOUND));
+        // 주문에 연관되어 있는 제품이면 삭제 불가능
+        if (orderRepository.existsByProduct(product)) {
+            throw new CustomException(InventoryErrorCode.ORDER_RELATED);
+        }
         productRepository.deleteById(product.getId());
         product.getInventory()
                 .updateUpdatedAt();

--- a/yellobook-common/src/main/java/com/yellobook/error/code/InventoryErrorCode.java
+++ b/yellobook-common/src/main/java/com/yellobook/error/code/InventoryErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum InventoryErrorCode implements ErrorCode {
     INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "INVENTORY-001", "해당 재고 현황은 존재하지 않습니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "INVENTORY-002", "해당 제품은 존재하지 않습니다."),
-    SKU_ALREADY_EXISTS(HttpStatus.CONFLICT, "INVENTORY-003", "이미 존재하는 품번입니다.");
+    SKU_ALREADY_EXISTS(HttpStatus.CONFLICT, "INVENTORY-003", "이미 존재하는 품번입니다."),
+    ORDER_RELATED(HttpStatus.CONFLICT, "INVENTORY-004", "주문과 연결되어 있는 제품이라서 삭제가 불가능합니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/yellobook-domain/src/main/java/com/yellobook/domains/order/repository/OrderRepository.java
+++ b/yellobook-domain/src/main/java/com/yellobook/domains/order/repository/OrderRepository.java
@@ -1,10 +1,12 @@
 package com.yellobook.domains.order.repository;
 
+import com.yellobook.domains.inventory.entity.Product;
 import com.yellobook.domains.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+    boolean existsByProduct(Product product);
 
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [Feature/YB-1]: 소셜 로그인 기능 구현)

## 📄 Work Description
<strong>Jira Ticket : `YB-593`</strong>
<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

[예시]
1. page, size 최솟값 설정 및 Unit Test 추가
    기존의 코드에는 page와 size의 범위 설정을 해주지 않아서 page가 1보다 작은 경우 에러가 발생했습니다. 이를 방지하기 위해 page와 size 둘다 1 이상의 정수만 전달 받을 수 있도록 설정했습니다.
    (코드 및 이미지 첨부)
-->

#### 1. 주문과 연관되어 있는 제품이면 삭제 못하도록 수정
기존의 코드에서는 제품을 forgien key로 가지고 있는 주문이 존재하는 상황에서 제품을 삭제하려고 하면 에러가 발생했습니다. 
따라서 주문과 연관이 되어 있는 제품을 삭제하려고 하는 경우 예외를 발생하도록 수정했습니다.


<br/>

## 💬 To Reviewers
<!--
어떤 부분을 유의해서 사용해야 하는지, 어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.
그 외 하고 싶은 말을 자유롭게 작성해주세요!

[예시]
- 팀스페이스 정보를 필요로 하지 않는 API의 경우에는 혹시 모를 에러를 방지하기 위해 `@AuthenticationPrincipal`를 사용하는 것이 좋을 것 같습니다!
-->


<br/>

## 🔗 Reference
[//]: # (문제를 해결하면서 도움이 되었거나 참고했던 사이트 또는 코드 첨부)

